### PR TITLE
fix: resolve GH_TOKEN at install time instead of host passthrough

### DIFF
--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -23,8 +23,9 @@
  *   4. rsyncs out/host/ contents to CONFIG_DIR.
  *   5. rsyncs out/sandbox/ contents to SANDBOX_CONFIG_DIR (if it exists).
  *   6. Deploys AoE config (resolving {{AGENT_VAULT}}, {{OPENCODE_CONFIG_SRC}},
- *      {{SANDBOX_CONFIG_DIR}}, and {{OPENCODE_DATA_DIR}}) — uses a profile-specific
- *      .aoe.toml if present, otherwise falls back to src/aoe-config.toml.
+ *      {{SANDBOX_CONFIG_DIR}}, {{OPENCODE_DATA_DIR}}, and {{GH_TOKEN}}) — uses
+ *      a profile-specific .aoe.toml if present, otherwise falls back to
+ *      src/aoe-config.toml.
  *   7. Prints a deployment summary.
  *
  * Separation of concerns:
@@ -451,6 +452,19 @@ Options:
       );
       content = content.replaceAll("{{SANDBOX_CONFIG_DIR}}", sandboxConfigDir);
       content = content.replaceAll("{{OPENCODE_DATA_DIR}}", opencodeDataDir);
+
+      // Resolve GH_TOKEN from the host environment
+      const ghToken = Bun.env.GH_TOKEN ?? "";
+      if (!ghToken) {
+        console.error(
+          "Warning: GH_TOKEN not set — sandbox will have no GitHub authentication.",
+        );
+        console.error(
+          "  Set GH_TOKEN in your environment and re-run install to fix this.",
+        );
+      }
+      content = content.replaceAll("{{GH_TOKEN}}", ghToken);
+
       writeFileSync(aoeDest, content, "utf-8");
       console.log(`AoE config deployed to: ${aoeDest}`);
       console.log(`  Source: ${aoeSrc}`);

--- a/src/aoe-config.toml
+++ b/src/aoe-config.toml
@@ -6,8 +6,11 @@
 # ~/.config/agent-of-empires/config.toml.
 #
 # Requires on host:
-#   export GH_TOKEN=$(gh auth token 2>/dev/null)
 #   export NTFY_TOPIC="<your-ntfy-topic>"
+#
+# GH_TOKEN is resolved from $GH_TOKEN at install time via the {{GH_TOKEN}}
+# placeholder. If GH_TOKEN is not set in the environment when install.ts runs,
+# a warning is printed and the sandbox will have no GitHub authentication.
 
 [session]
 default_tool = "opencode"
@@ -30,7 +33,7 @@ environment = [
     "AGENT_VAULT=/root/obsidian/agent.obs",
     "AGENT_REPOS=/workspace",
     "OPENCODE_CONFIG_SRC=/root/.config/opencode",
-    "GH_TOKEN",
+    "GH_TOKEN={{GH_TOKEN}}",
     "NTFY_TOPIC",
     "GIT_CONFIG_COUNT=2",
     "GIT_CONFIG_KEY_0=credential.https://github.com.helper",

--- a/src/profiles/gh.aoe.toml
+++ b/src/profiles/gh.aoe.toml
@@ -7,8 +7,11 @@
 # {{SANDBOX_CONFIG_DIR}}, and {{OPENCODE_DATA_DIR}} at deploy time.
 #
 # Requires on host:
-#   export GH_TOKEN=$(gh auth token 2>/dev/null)
 #   export NTFY_TOPIC="<your-ntfy-topic>"
+#
+# GH_TOKEN is resolved from $GH_TOKEN at install time via the {{GH_TOKEN}}
+# placeholder. If GH_TOKEN is not set in the environment when install.ts runs,
+# a warning is printed and the sandbox will have no GitHub authentication.
 
 [session]
 default_tool = "opencode"
@@ -32,11 +35,11 @@ environment = [
     "AGENT_REPOS=/workspace",
     "OPENCODE_CONFIG_SRC=/root/.config/opencode",
 
-    # GH_TOKEN (bare key = passthrough from host): needed for `gh` CLI API calls
-    # (issues, PRs, releases) even though git operations use SSH. The HTTPS
-    # credential helper (KEY_0/VALUE_0) is kept as a fallback for any HTTPS git
-    # operation that bypasses the insteadOf rewrite (e.g. explicit HTTPS remotes).
-    "GH_TOKEN",
+    # GH_TOKEN: resolved at install time from $GH_TOKEN. Needed for `gh` CLI
+    # API calls (issues, PRs, releases) even though git operations use SSH.
+    # The HTTPS credential helper (KEY_0/VALUE_0) is kept as a fallback for
+    # any HTTPS git operation that bypasses the insteadOf rewrite.
+    "GH_TOKEN={{GH_TOKEN}}",
     "NTFY_TOPIC",
     # Git config: HTTPS credential helper + protocol v2 + SSH-prefer URL rewrite.
     # The insteadOf rule (KEY_2/VALUE_2) rewrites https://github.com/ URLs to


### PR DESCRIPTION
     ## Summary
     - Replace bare `"GH_TOKEN"` (Docker-style host env passthrough) with `"GH_TOKEN={{GH_TOKEN}}"` placeholder in both AoE config templates
     - `install.ts` now reads `$GH_TOKEN` from the host environment at install time and stamps the actual token value into the deployed `~/.config/agent-of-empires/config.toml`
     - Warns if `GH_TOKEN` is not set when running install