### PR TITLE
Add github skill and github_comment tool for unified GitHub commenting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ opencode-config/
 │   │   ├── vault.ts           #     Barrel export for vault/ tools
 │   │   ├── create_issue.ts    #     GitHub issue creation from schema
 │   │   ├── create_pr.ts       #     PR creation from commit log
+│   │   ├── github_comment.ts  #     GitHub comment posting with auto-footer
 │   │   ├── delegate/          #     Delegation tools
 │   │   │   ├── _lib.ts        #       Shared delegate helpers
 │   │   │   ├── session.ts     #       delegate tool (single session)
@@ -89,6 +90,7 @@ opencode-config/
 │   ├── skills/                #   Loadable skill instruction sets
 │   │   ├── auto-impl/        #     Autonomous schema execution skill
 │   │   ├── delegate/         #     AoE delegation skill
+│   │   ├── github/           #     GitHub comment templates and conventions
 │   │   ├── research-check/   #     SKILL.md + check.sh (notes freshness)
 │   │   ├── vault-init/       #     SKILL.md (vault directory init)
 │   │   └── vault-triage/     #     SKILL.md + setup.sh + toast-handler.sh
@@ -185,7 +187,7 @@ Research ──► Plan ──────► Implement ──────► Re
   creates a GitHub issue, and links it into the schema.
 - **Write access:** Full vault mutations (schemas and drafts); GitHub issue
   creation and project board adds (both require user approval via `ask`);
-  `gh pr comment*` (ask — to cross-reference PRs when creating a related issue).
+  `github_comment` (ask — to cross-reference PRs when creating a related issue).
 - **Post-schema:** Archives source drafts from `$AGENT_VAULT/drafts/` to `$AGENT_VAULT/_misc/archive/` with a date prefix.
 - **Does not:** Implement anything; write outside the vault.
 
@@ -197,8 +199,8 @@ Research ──► Plan ──────► Implement ──────► Re
   `$AGENT_VAULT/projects/<owner>/<repo>.md` status documents, and runs
   `vault_gc`/`vault_lint` as part of project cleanup.
 - **Write access:** All `gh issue *`, `gh project *`, `gh label *`, and
-  `gh api repos/*/milestones` mutations; `gh pr comment*`; `vault_gc` and
-  `vault_lint` tools.
+  `gh api repos/*/milestones` mutations; `github_comment` (for PR
+  cross-references); `vault_gc` and `vault_lint` tools.
 - **Does not:** Edit source files; run any git write command; merge or close PRs;
   create or delete repositories; operate on repos not in the vault.
 
@@ -213,7 +215,8 @@ Research ──► Plan ──────► Implement ──────► Re
 - **Write access:** Full repository edits, `git add`, `git switch`,
   `git checkout`, build/test tools, `gh issue edit`/`comment`. Uses custom tools
   for frontmatter (`fm_read`/`fm_write`), worktree ops (`wt_detect`/`wt_switch_branch`),
-  notifications (`notify_triage`), and issue creation (`create_issue`).
+  notifications (`notify_triage`), issue creation (`create_issue`), and GitHub
+  commenting (`github_comment` — loads `github` skill for templates).
 - **Does not:** `git commit` (the user does that); push; skip approval gates.
 
 #### `auto-impl` skill — autonomous schema execution
@@ -319,6 +322,7 @@ detailed instructions and references to bundled scripts.
 | ---------------- | ---------------------------- | ------------------------------------------------------------------------------------------ |
 | `auto-impl`      | `src/skills/auto-impl/`      | Autonomous schema execution — turns build mode into an orchestrator                        |
 | `delegate`       | `src/skills/delegate/`       | Fleet orchestration — compose/approve/dispatch workflow with opencode and copilot backends |
+| `github`         | `src/skills/github/`         | Comment templates and conventions for issue/PR commenting with auto-footer                 |
 | `research-check` | `src/skills/research-check/` | Check notes freshness against current repo state; outputs structured staleness report      |
 | `vault-init`     | `src/skills/vault-init/`     | Initialize or verify the vault directory structure; use the `vault_init` tool              |
 | `vault-triage`   | `src/skills/vault-triage/`   | Write triage entries and send push notifications                                           |
@@ -343,7 +347,7 @@ call tools directly — there are no shell scripts to invoke.
 | Notify      | `notify_triage`, `session_notify`                                                                                                                  |
 | Triage      | `triage_write`                                                                                                                                     |
 | Vault       | `vault_cache`, `vault_edit`, `vault_find`, `vault_gc`, `vault_init`, `vault_lint`, `vault_ls`, `vault_mv`, `vault_read`, `vault_rm`, `vault_write` |
-| GitHub      | `create_issue`, `create_pr`                                                                                                                        |
+| GitHub      | `create_issue`, `create_pr`, `github_comment`                                                                                                      |
 | Other       | `delegate`, `delegate_fleet`, `local_ci`                                                                                                           |
 
 ---
@@ -543,8 +547,16 @@ This applies to `@planner` (ask) and `@project-manager` (allow). The
 `auto-impl` skill also posts cross-reference comments when escalations create
 issues. `@reviewer` does not create issues and is therefore exempt.
 
-```bash
-gh pr comment <pr-number> -R <owner>/<repo> --body "Opened #<issue-number> to track <short description>."
+Use the `github_comment` tool (which auto-appends a disclosure footer):
+
+```
+github_comment({
+  repo: "<owner>/<repo>",
+  number: <pr-number>,
+  body: "Opened #<issue-number> to track <short description>.",
+  agent: "<agent-name>",
+  type: "pr"
+})
 ```
 
 ---

--- a/src/agents/implementor.md
+++ b/src/agents/implementor.md
@@ -83,6 +83,10 @@ and prints the updated working path (see Behavior §3 below).
 
 ### Status tracking
 
+> **GitHub comments:** Load the `github` skill (`skill("github")`) before
+> posting comments. Use the `github_comment` tool — it auto-appends a
+> disclosure footer.
+
 - **On startup:** After reading the schema and switching to the branch, update
   the schema status to `🔨 in-progress`:
   ```
@@ -100,13 +104,15 @@ and prints the updated working path (see Behavior §3 below).
   ```
   This is best-effort and never blocks the startup sequence.
 - **Also on startup:** Post a start comment on the linked GitHub issue (skip if vault-only or blank).
-  Reuse the `issue_field` and `repo_slug` from above:
-  ```bash
-  _issue_num="$(echo "$issue_field" | grep -oP '#\K[0-9]+')"
-  _group_count="$(grep -c '^### Commit group\|^## [0-9]' "$schema_file" 2>/dev/null || echo '?')"
-  gh issue comment "$_issue_num" -R "$repo_slug" \
-    --body "Implementation started on branch \`${branch}\`. Schema: ${_group_count} commit groups. Started at $(date -u '+%Y-%m-%d %H:%M UTC')." \
-    2>/dev/null || true
+  Reuse the `_issue_num` and `repo_slug` from above. Load the `github` skill
+  and use the `github_comment` tool:
+  ```
+  github_comment({
+    repo: repo_slug,
+    number: _issue_num,
+    body: "### Changed\n\nImplementation started on branch `${branch}`.\n\n### Validation\n\n- Schema: ${_group_count} commit groups\n- Started at: ${datetime}",
+    agent: "implementor"
+  })
   ```
   This is best-effort and never blocks the startup sequence.
 - **After final commit group:** When all commit groups are complete and validated,
@@ -126,12 +132,14 @@ and prints the updated working path (see Behavior §3 below).
   ```
   This is best-effort and never blocks the completion sequence.
 - **Also on completion:** Post a completion comment on the linked GitHub issue (skip if vault-only or blank).
-  Reuse the `issue_field` and `repo_slug` from above:
-  ```bash
-  _issue_num="$(echo "$issue_field" | grep -oP '#\K[0-9]+')"
-  gh issue comment "$_issue_num" -R "$repo_slug" \
-    --body "Implementation complete on branch \`${branch}\`. All commit groups implemented and validated." \
-    2>/dev/null || true
+  Reuse the `_issue_num` and `repo_slug` from above. Use the `github_comment` tool:
+  ```
+  github_comment({
+    repo: repo_slug,
+    number: _issue_num,
+    body: "### Changed\n\nImplementation complete on branch `${branch}`.\nAll commit groups implemented and validated.",
+    agent: "implementor"
+  })
   ```
   This is best-effort and never blocks the completion sequence.
 - **Worktree cleanup suggestion:** If a new worktree was created during startup

--- a/src/agents/planner.md
+++ b/src/agents/planner.md
@@ -89,9 +89,16 @@ automatically if the repo uses the bare/worktree layout.
 8. **Link** the issue back into the schema header.
 9. **Cross-reference PRs** — if the issue you just created relates to an open
    PR (e.g., a bug found during CI, a design question from review, a follow-up
-   task), post a comment on the PR:
-   ```bash
-   gh pr comment <pr-number> -R <owner>/<repo> --body "Opened #<issue-number> to track <short description>."
+   task), post a comment on the PR. Load the `github` skill and use the
+   `github_comment` tool:
+   ```
+   github_comment({
+     repo: "<owner>/<repo>",
+     number: <pr-number>,
+     body: "Opened #<issue-number> to track <short description>.",
+     agent: "planner",
+     type: "pr"
+   })
    ```
    Skip this step if there is no related PR or if the issue is the PR's own
    tracking issue.

--- a/src/agents/project-manager.md
+++ b/src/agents/project-manager.md
@@ -55,7 +55,17 @@ Human-invoked sessions where PM performs GitHub and vault operations on request.
 3. Optionally run `vault_lint({})` and surface any violations.
 4. For bulk operations affecting more than one item: enumerate all affected items, present a numbered summary table ("Will close N issues: #12, #14, #17 …"), and wait for explicit user "yes" before executing.
 5. Execute GitHub mutations (`gh issue close`, `gh project item-edit`, etc.) for each item.
-6. If you created an issue during this session that relates to an open PR (and the issue is not the PR's own tracking issue), post a cross-reference comment on the PR: `gh pr comment <pr-number> -R <owner>/<repo> --body "Opened #<issue-number> to track <short description>."` Skip if no issue was created or no related PR exists.
+6. If you created an issue during this session that relates to an open PR (and the issue is not the PR's own tracking issue), load the `github` skill and post a cross-reference comment using the `github_comment` tool:
+   ```
+   github_comment({
+     repo: "<owner>/<repo>",
+     number: <pr-number>,
+     body: "Opened #<issue-number> to track <short description>.",
+     agent: "project-manager",
+     type: "pr"
+   })
+   ```
+   Skip if no issue was created or no related PR exists.
 7. Update `$vault/projects/<owner>/<repo>.md` (create if absent, update `last_synced` and tables).
 8. After GitHub mutations, optionally run `vault_gc({})`.
 

--- a/src/skills/auto-impl/SKILL.md
+++ b/src/skills/auto-impl/SKILL.md
@@ -49,6 +49,9 @@ review_file="$task_dir/reviews/review.md"
 
 Then execute these steps in order:
 
+> **GitHub comments:** The `github` skill should be loaded at the start of
+> the session. Use `github_comment` for all issue/PR comments.
+
 1. **Read `CONTRIBUTING.md`** from `$repo_path` root (if it exists). This
    provides project conventions for the implementation.
 
@@ -89,13 +92,16 @@ Then execute these steps in order:
    gh issue edit "$_issue_num" -R "$repo_slug" --add-label "in-progress" 2>/dev/null || true
    ```
 
-6. **Post a start comment** on the linked issue (best-effort):
+6. **Post a start comment** on the linked issue (best-effort). Use the
+   `github_comment` tool:
 
-   ```bash
-   _group_count="$(grep -c '^### Commit' "$schema_file" 2>/dev/null || echo '?')"
-   gh issue comment "$_issue_num" -R "$repo_slug" \
-     --body "Implementation started on branch \`${branch}\`. Schema: ${_group_count} commit groups. Started at $(date -u '+%Y-%m-%d %H:%M UTC')." \
-     2>/dev/null || true
+   ```
+   github_comment({
+     repo: repo_slug,
+     number: _issue_num,
+     body: "### Changed\n\nImplementation started on branch `${branch}`.\n\n### Validation\n\n- Schema: ${_group_count} commit groups\n- Started at: ${datetime}",
+     agent: "auto-impl"
+   })
    ```
 
 7. **Check for partial run recovery.** If the schema status was already
@@ -223,12 +229,16 @@ After all commit groups are done and validated:
    gh issue edit "$_issue_num" -R "$repo_slug" --remove-label "in-progress" 2>/dev/null || true
    ```
 
-3. **Post a completion comment** on the linked issue (best-effort):
+3. **Post a completion comment** on the linked issue (best-effort). Use the
+   `github_comment` tool:
 
-   ```bash
-   gh issue comment "$_issue_num" -R "$repo_slug" \
-     --body "Implementation complete on branch \`${branch}\`. ${_groups_completed} commit groups implemented and validated." \
-     2>/dev/null || true
+   ```
+   github_comment({
+     repo: repo_slug,
+     number: _issue_num,
+     body: "### Changed\n\nImplementation complete on branch `${branch}`.\n${_groups_completed} commit groups implemented and validated.",
+     agent: "auto-impl"
+   })
    ```
 
 4. **Write a `run-summary` triage entry.** Include: commit groups completed,

--- a/src/skills/github/SKILL.md
+++ b/src/skills/github/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: github
+description: >
+  Templates and conventions for posting structured comments on GitHub
+  issues and PRs. Load this skill before using the github_comment tool.
+---
+
+# GitHub Comment Skill
+
+## Overview
+
+This skill provides templates and conventions for all agent-generated
+GitHub comments. Load it before posting comments using the
+`github_comment` tool.
+
+## Footer Convention
+
+Every auto-generated comment MUST include a disclosure footer. The
+`github_comment` tool appends this automatically:
+
+```
+---
+*Posted by **<agent>** at YYYY-MM-DD HH:MM UTC*
+```
+
+Do NOT manually append footers — the tool handles this.
+
+## Comment Templates
+
+### Implementation Start
+
+Used by `@implementor` and `auto-impl` when beginning schema execution.
+
+```markdown
+### Changed
+
+Implementation started on branch `<branch>`.
+
+### Validation
+
+- Schema: <N> commit groups
+- Started at: <datetime>
+```
+
+### Implementation Complete
+
+Used by `@implementor` and `auto-impl` when all commit groups are done.
+
+```markdown
+### Changed
+
+Implementation complete on branch `<branch>`.
+All <N> commit groups implemented and validated.
+```
+
+### Commit Group Complete
+
+Used by `auto-impl` after each commit group's review loop.
+
+```markdown
+### Changed
+
+Commit group <N>/<total> complete.
+
+### Validation
+
+- Tests: <pass/fail>
+- Review rounds: <count>
+```
+
+### Cross-Reference
+
+Used by `@planner` and `@project-manager` to link issues and PRs.
+
+```markdown
+Opened #<issue-number> to track <short description>.
+```
+
+### Review Summary
+
+Used by `auto-impl` to post review outcomes on issues.
+
+```markdown
+### Changed
+
+Review round <N> complete for commit group <G>.
+
+### Validation
+
+- Findings: <count> (high: <n>, medium: <n>, low: <n>)
+- Status: <resolved/escalated>
+
+### Deferred
+
+- <items left for later, if any>
+```
+
+## Tool Reference
+
+Use the `github_comment` tool to post comments:
+
+```
+github_comment({
+  repo: "owner/repo",
+  number: 42,
+  body: "<comment body following templates above>",
+  agent: "implementor",
+  type: "issue"   // or "pr"
+})
+```
+
+The tool auto-appends the footer. Do NOT include the footer in `body`.
+
+## When to Load This Skill
+
+Load this skill (`skill("github")`) before any of these operations:
+
+- Posting implementation start/complete comments
+- Posting commit group status updates
+- Cross-referencing issues and PRs
+- Posting review summaries
+
+The skill is explicitly loaded — it is NOT baked into agent prompts.

--- a/src/tools/github_comment.ts
+++ b/src/tools/github_comment.ts
@@ -1,0 +1,54 @@
+import { tool } from "@opencode-ai/plugin";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Build the disclosure footer appended to every agent-generated comment.
+ * Exported for testability.
+ */
+export function buildFooter(agent: string, now?: Date): string {
+  const d = now ?? new Date();
+  const ts = d.toISOString().replace("T", " ").slice(0, 16) + " UTC";
+  return `\n\n---\n*Posted by **${agent}** at ${ts}*`;
+}
+
+export default tool({
+  description:
+    "Post a comment on a GitHub issue or PR with an auto-appended " +
+    "agent disclosure footer. Wraps gh issue comment / gh pr comment.",
+  args: {
+    repo: tool.schema
+      .string()
+      .describe("GitHub owner/repo slug (e.g. 'ada-x64/opencode-config')"),
+    number: tool.schema.number().describe("Issue or PR number"),
+    body: tool.schema
+      .string()
+      .describe("Comment body in Markdown (footer is appended automatically)"),
+    agent: tool.schema
+      .string()
+      .describe("Agent name for the disclosure footer (e.g. 'implementor')"),
+    type: tool.schema
+      .enum(["issue", "pr"])
+      .optional()
+      .describe("Comment target type (default: 'issue')"),
+  },
+  async execute(args) {
+    const type = args.type ?? "issue";
+    const footer = buildFooter(args.agent);
+    const fullBody = args.body + footer;
+
+    // Write to temp file for safe multi-line handling
+    const tmpDir = await mkdtemp(join(tmpdir(), "gh-comment-"));
+    const tmpFile = join(tmpDir, "body.md");
+    try {
+      await writeFile(tmpFile, fullBody, "utf-8");
+      const cmd = type === "pr" ? "pr" : "issue";
+      const result =
+        await Bun.$`gh ${cmd} comment ${args.number} -R ${args.repo} --body-file ${tmpFile}`.text();
+      return result.trim();
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  },
+});

--- a/tests/tools/github-comment.test.ts
+++ b/tests/tools/github-comment.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "bun:test";
+import github_comment, { buildFooter } from "../../src/tools/github_comment";
+
+describe("github_comment", () => {
+  describe("tool shape", () => {
+    it("has the correct description", () => {
+      expect(github_comment.description).toContain(
+        "Post a comment on a GitHub issue or PR",
+      );
+    });
+
+    it("declares required args", () => {
+      expect(github_comment.args).toHaveProperty("repo");
+      expect(github_comment.args).toHaveProperty("number");
+      expect(github_comment.args).toHaveProperty("body");
+      expect(github_comment.args).toHaveProperty("agent");
+    });
+
+    it("declares optional type arg", () => {
+      expect(github_comment.args).toHaveProperty("type");
+    });
+  });
+
+  describe("buildFooter", () => {
+    it("produces the expected format", () => {
+      const date = new Date("2026-04-09T14:30:00.000Z");
+      const footer = buildFooter("implementor", date);
+      expect(footer).toBe(
+        "\n\n---\n*Posted by **implementor** at 2026-04-09 14:30 UTC*",
+      );
+    });
+
+    it("handles different agent names", () => {
+      const date = new Date("2026-01-15T09:00:00.000Z");
+      const footer = buildFooter("planner", date);
+      expect(footer).toContain("**planner**");
+      expect(footer).toContain("2026-01-15 09:00 UTC");
+    });
+
+    it("handles auto-impl agent name", () => {
+      const date = new Date("2026-06-01T00:00:00.000Z");
+      const footer = buildFooter("auto-impl", date);
+      expect(footer).toContain("**auto-impl**");
+    });
+
+    it("starts with double newline and separator", () => {
+      const footer = buildFooter("test", new Date());
+      expect(footer.startsWith("\n\n---\n")).toBe(true);
+    });
+
+    it("ends with UTC suffix", () => {
+      const footer = buildFooter("test", new Date());
+      expect(footer.endsWith("UTC*")).toBe(true);
+    });
+  });
+
+  describe("body assembly", () => {
+    it("appends footer to body without double separators", () => {
+      const body = "### Changed\n\nSome work done.";
+      const footer = buildFooter(
+        "implementor",
+        new Date("2026-04-09T12:00:00Z"),
+      );
+      const fullBody = body + footer;
+
+      // Should have exactly one "---" separator (from the footer)
+      const separators = fullBody.match(/\n---\n/g);
+      expect(separators).toHaveLength(1);
+    });
+
+    it("handles body with existing horizontal rules", () => {
+      const body = "Part 1\n\n---\n\nPart 2";
+      const footer = buildFooter("reviewer", new Date("2026-04-09T12:00:00Z"));
+      const fullBody = body + footer;
+
+      // Body has its own --- plus the footer ---
+      const separators = fullBody.match(/\n---\n/g);
+      expect(separators).toHaveLength(2);
+    });
+
+    it("handles empty body", () => {
+      const body = "";
+      const footer = buildFooter(
+        "implementor",
+        new Date("2026-04-09T12:00:00Z"),
+      );
+      const fullBody = body + footer;
+
+      expect(fullBody).toContain("**implementor**");
+      expect(fullBody.startsWith("\n\n---")).toBe(true);
+    });
+  });
+
+  describe("default type", () => {
+    it("type defaults to issue when omitted from args schema", () => {
+      // The schema declares type as optional — verify the args definition exists
+      // and accepts "issue" and "pr" as enum values
+      const typeArg = github_comment.args.type;
+      expect(typeArg).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `github` skill and `github_comment` tool that unify all agent-generated
GitHub comments behind a single tool with an auto-appended disclosure footer.
Replaces 6 inline `gh issue/pr comment` bash blocks across 4 agent/skill files.

- **New `github` skill** (`src/skills/github/SKILL.md`) — comment templates
  (start, complete, cross-reference, review summary) and footer convention
- **New `github_comment` tool** (`src/tools/github_comment.ts`) — wraps
  `gh issue/pr comment` with temp file + `--body-file`, auto-appends
  `*Posted by **<agent>** at <datetime>*` footer
- **Refactored agents:** `implementor.md`, `auto-impl/SKILL.md`, `planner.md`,
  `project-manager.md` — all inline `gh comment` blocks replaced with
  `github_comment` tool calls; label transitions (`gh issue edit`) unchanged
- **Updated `AGENTS.md`** — skill/tool in layout tree, tables, agent references,
  and PR-Issue cross-reference section

## Validation

- `bun test` — 216/216 passing (12 new tests for `github_comment`)
- `prettier --check .` — all files clean
- No remaining inline `gh issue/pr comment` in refactored files
- All `gh issue edit --add-label/--remove-label` blocks preserved

## Stats

8 files changed (3 new, 5 modified)