### PR TITLE
feat: update build.ts sandbox default from /root/.config/opencode to /data/config

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -743,8 +743,7 @@ export function build(
   const extDirs = globalSection.external_directory;
 
   if (sandboxConfigDirValue === null) {
-    sandboxConfigDirValue =
-      globalSection.sandbox_config_dir ?? "/data/config";
+    sandboxConfigDirValue = globalSection.sandbox_config_dir ?? "/data/config";
   }
 
   const outRoot = path.join(REPO_ROOT, "out");

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -71,7 +71,7 @@ const DEFAULT_CONFIG: BuildConfig = {
       "{env:OPENCODE_CONFIG_SRC}/**",
       "/tmp/**",
     ],
-    sandbox_config_dir: "/root/.config/opencode",
+    sandbox_config_dir: "/data/config",
   },
   tiers: {
     design: { model: null },
@@ -744,7 +744,7 @@ export function build(
 
   if (sandboxConfigDirValue === null) {
     sandboxConfigDirValue =
-      globalSection.sandbox_config_dir ?? "/root/.config/opencode";
+      globalSection.sandbox_config_dir ?? "/data/config";
   }
 
   const outRoot = path.join(REPO_ROOT, "out");


### PR DESCRIPTION
## Summary

Updates the build system's sandbox default path to match the new Docker `/data/` mount layout.

Split from #63 (PR D of 5). Depends on #80 (Docker image overhaul).

### Changes

- **`scripts/build.ts`** — both occurrences of `/root/.config/opencode` updated to `/data/config` (the `DEFAULT_CONFIG` default and the fallback in `build()`)
- Style: prettier formatting fix

### Testing

- All 216 tests pass

### Dependency chain

```
  A (#79) → B (#81)      ─┐
                           ├→ E (docs)
  C (#80) → D (this PR)  ─┘
```