### PR TITLE
fix: resolve Docker sandbox UID collision and AoE bind-mount config issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -625,7 +625,7 @@ calls fail silently if ntfy is not configured, so they never block agent work.
 | `AGENT_VAULT`        | Yes (for vault ops) | Absolute path to the Obsidian vault   | None — must be set                  |
 | `AGENT_REPOS`        | Yes (for repo ops)  | Absolute path to local repo checkouts | None — must be set                  |
 | `NTFY_TOPIC`         | No                  | ntfy.sh topic for push notifications  | `$AGENT_VAULT/_misc/ntfy-topic.txt` |
-| `SANDBOX_CONFIG_DIR` | No                  | Path where sandbox config is deployed | `$HOME/.config/opencode-sandbox`    |
+| `SANDBOX_CONFIG_DIR` | No                  | Path where sandbox config is deployed | `$HOME/.config/opencode/sandbox`    |
 
 `AGENT_VAULT` and `AGENT_REPOS` are checked at the top of any agent session
 that uses the vault or operates on a repository. The `vault-init` skill can

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ in `src/` are never modified. All stamping happens on the copies in `out/`.
 ```
 src/ ──build.ts──► out/host/    ──install.ts──► ~/.config/opencode
                                                   (or custom CONFIG_DIR)
-               ├─► out/sandbox/ ──install.ts──► ~/.config/opencode-sandbox
+               ├─► out/sandbox/ ──install.ts──► ~/.config/opencode/sandbox
                      ▲                            (or SANDBOX_CONFIG_DIR)
                build.json
             (model tiers, external_directory)
@@ -107,7 +107,7 @@ Path resolution order: CLI flag → env var → default.
 | Flag                    | Env var               | Default                          |
 | ----------------------- | --------------------- | -------------------------------- |
 | `--opencode-config-dir` | `OPENCODE_CONFIG_DIR` | `~/.config/opencode`             |
-| `--sandbox-config-dir`  | `SANDBOX_CONFIG_DIR`  | `~/.config/opencode-sandbox`     |
+| `--sandbox-config-dir`  | `SANDBOX_CONFIG_DIR`  | `~/.config/opencode/sandbox`     |
 | `--profiles-config`     | `OCCONF_PROFILES`     | `~/.config/occonf/profiles.toml` |
 
 ### `scripts/setup.ts`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,6 +65,11 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
 RUN curl -fsSL https://opencode.ai/install | bash \
     && mv /root/.opencode/bin/opencode /usr/local/bin/opencode
 
+# Docker CLI (static binary — for Docker socket access, local CI, AoE dispatch)
+RUN ARCH=$(uname -m) && \
+    curl -fsSL "https://download.docker.com/linux/static/stable/${ARCH}/docker-27.5.1.tgz" \
+      | tar -xz --strip-components=1 -C /usr/local/bin/ docker/docker
+
 # Generic mount points (not tied to /root/)
 RUN mkdir -p /data/vault /data/config /data/opencode-data /workspace
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -55,24 +55,68 @@ if [[ -n "${SANDBOX_USER:-}" ]]; then
 	done
 
 	# Set HOME for the target user
-    export HOME="/home/$SANDBOX_USER"
+	export HOME="/home/$SANDBOX_USER"
 
-    # Grant Docker socket access if mounted
-    if [[ -S /var/run/docker.sock ]]; then
-        docker_gid=$(stat -c '%g' /var/run/docker.sock)
-        groupadd -g "$docker_gid" docker 2>/dev/null || true
-        usermod -aG docker "$SANDBOX_USER" 2>/dev/null || true
-    fi
+	# Grant Docker socket access if mounted
+	if [[ -S /var/run/docker.sock ]]; then
+		docker_gid=$(stat -c '%g' /var/run/docker.sock)
+		# Evict collisions (same pattern as sandbox group above)
+		existing_docker_group=$(getent group "$docker_gid" 2>/dev/null | cut -d: -f1 || true)
+		if [[ -n "$existing_docker_group" && "$existing_docker_group" != "docker" ]]; then
+			groupdel "$existing_docker_group" 2>/dev/null || true
+		fi
+		existing_docker_gid=$(getent group docker 2>/dev/null | cut -d: -f3 || true)
+		if [[ -n "$existing_docker_gid" && "$existing_docker_gid" != "$docker_gid" ]]; then
+			groupmod -g "$docker_gid" docker 2>/dev/null || true
+		fi
+		groupadd -g "$docker_gid" docker 2>/dev/null || true
+		usermod -aG docker "$SANDBOX_USER" 2>/dev/null || true
+	fi
 fi
 
 # Bridge /data/config → $HOME/.config/opencode so opencode finds its config.
 # Bridge /data/opencode-data → $HOME/.local/share/opencode for state/database.
 # Must run after HOME is set (either /home/$SANDBOX_USER or default /root).
-mkdir -p "$HOME/.config" "$HOME/.local/share"
-ln -sfn /data/config "$HOME/.config/opencode"
-ln -sfn /data/opencode-data "$HOME/.local/share/opencode"
+#
+# AoE may bind-mount its own config sync directory directly onto
+# /root/.config/opencode before the entrypoint runs. A bind mount cannot be
+# replaced with a symlink, so we detect it and populate the mount with
+# symlinks to the individual items in /data/config instead.
+bridge_config() {
+	local target="$1" source="$2"
+	mkdir -p "$(dirname "$target")"
+	if mountpoint -q "$target" 2>/dev/null; then
+		# Target is a bind mount — symlink each item from source into it.
+		# Existing files in the mount (e.g. opencode.json synced by AoE)
+		# are left alone; only missing items are linked.
+		local prev_nullglob
+		prev_nullglob=$(shopt -p nullglob || true)
+		shopt -s nullglob
+		for item in "$source"/*; do
+			local name
+			name=$(basename "$item")
+			if [[ ! -e "$target/$name" ]]; then
+				ln -sfn "$item" "$target/$name"
+			fi
+		done
+		$prev_nullglob
+	else
+		# No mount — replace with a single directory symlink.
+		ln -sfn "$source" "$target"
+	fi
+}
 
+bridge_config "$HOME/.config/opencode" /data/config
+bridge_config "$HOME/.local/share/opencode" /data/opencode-data
+
+# When SANDBOX_USER is set, HOME differs from /root. AoE's docker exec
+# runs as root, so also bridge /root paths to ensure opencode works
+# regardless of which user invokes it.
 if [[ -n "${SANDBOX_USER:-}" ]]; then
+	mkdir -p /root/.config /root/.local/share
+	bridge_config /root/.config/opencode /data/config
+	bridge_config /root/.local/share/opencode /data/opencode-data
+
 	# Ensure the symlink parents are owned by the target user
 	chown -R "${SANDBOX_UID}:${SANDBOX_GID}" "$HOME/.config" "$HOME/.local" 2>/dev/null || true
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,29 +2,60 @@
 set -euo pipefail
 
 if [[ -n "${SANDBOX_USER:-}" ]]; then
-    sandbox_group="${SANDBOX_GROUP:-agents}"
-    sandbox_uid="${SANDBOX_UID:-1000}"
-    sandbox_gid="${SANDBOX_GID:-1000}"
+	sandbox_group="${SANDBOX_GROUP:-agents}"
+	sandbox_uid="${SANDBOX_UID:-1000}"
+	sandbox_gid="${SANDBOX_GID:-1000}"
 
-    # Create group (ignore if exists)
-    groupadd -g "$sandbox_gid" "$sandbox_group" 2>/dev/null || true
+	# Ensure the target group and user exist with the correct UID/GID.
+	# ubuntu:24.04 ships with 'ubuntu' at 1000:1000 which collides with
+	# the default SANDBOX_UID/GID. Without eviction, groupadd/useradd
+	# fail silently (|| true) and gosu crashes because the target user
+	# was never created.
+	#
+	# Strategy: evict users before groups (groupdel refuses to remove a
+	# group that is any user's primary group). Use usermod/groupmod to
+	# fix collisions by name when possible, since the colliding entry
+	# may have dependents that block deletion.
 
-    # Create user with home directory (ignore if exists)
-    useradd -u "$sandbox_uid" -g "$sandbox_gid" \
-        -m -s /bin/bash "$SANDBOX_USER" 2>/dev/null || true
+	# --- UID collision: different user occupying the target UID ---
+	existing_user=$(getent passwd "$sandbox_uid" 2>/dev/null | cut -d: -f1 || true)
+	if [[ -n "$existing_user" && "$existing_user" != "$SANDBOX_USER" ]]; then
+		userdel -r "$existing_user" 2>/dev/null || true
+	fi
+	# --- Username collision: right name, wrong UID ---
+	existing_uid=$(getent passwd "$SANDBOX_USER" 2>/dev/null | cut -d: -f3 || true)
+	if [[ -n "$existing_uid" && "$existing_uid" != "$sandbox_uid" ]]; then
+		userdel -r "$SANDBOX_USER" 2>/dev/null || true
+	fi
 
-    # Ensure bind-mount points are group-accessible.
-    # Only chmod the mount-point itself (not -R) to avoid mutating host
-    # file permissions through bind-mounts.
-    for dir in /data/vault /data/config /data/opencode-data /workspace; do
-        if [[ -d "$dir" ]]; then
-            chgrp "$sandbox_group" "$dir" 2>/dev/null || true
-            chmod g+rwX "$dir" 2>/dev/null || true
-        fi
-    done
+	# --- GID collision: different group occupying the target GID ---
+	existing_group=$(getent group "$sandbox_gid" 2>/dev/null | cut -d: -f1 || true)
+	if [[ -n "$existing_group" && "$existing_group" != "$sandbox_group" ]]; then
+		groupdel "$existing_group" 2>/dev/null || true
+	fi
+	# --- Group name collision: right name, wrong GID ---
+	existing_gid=$(getent group "$sandbox_group" 2>/dev/null | cut -d: -f3 || true)
+	if [[ -n "$existing_gid" && "$existing_gid" != "$sandbox_gid" ]]; then
+		groupmod -g "$sandbox_gid" "$sandbox_group" 2>/dev/null || true
+	fi
 
-    # Set HOME for the target user
-    export HOME="/home/$SANDBOX_USER"
+	# Create group and user (no-op if already correct)
+	groupadd -g "$sandbox_gid" "$sandbox_group" 2>/dev/null || true
+	useradd -u "$sandbox_uid" -g "$sandbox_gid" \
+		-m -s /bin/bash "$SANDBOX_USER" 2>/dev/null || true
+
+	# Ensure bind-mount points are group-accessible.
+	# Only chmod the mount-point itself (not -R) to avoid mutating host
+	# file permissions through bind-mounts.
+	for dir in /data/vault /data/config /data/opencode-data /workspace; do
+		if [[ -d "$dir" ]]; then
+			chgrp "$sandbox_group" "$dir" 2>/dev/null || true
+			chmod g+rwX "$dir" 2>/dev/null || true
+		fi
+	done
+
+	# Set HOME for the target user
+	export HOME="/home/$SANDBOX_USER"
 fi
 
 # Bridge /data/config → $HOME/.config/opencode so opencode finds its config.
@@ -35,11 +66,11 @@ ln -sfn /data/config "$HOME/.config/opencode"
 ln -sfn /data/opencode-data "$HOME/.local/share/opencode"
 
 if [[ -n "${SANDBOX_USER:-}" ]]; then
-    # Ensure the symlink parents are owned by the target user
-    chown -R "${SANDBOX_UID}:${SANDBOX_GID}" "$HOME/.config" "$HOME/.local" 2>/dev/null || true
+	# Ensure the symlink parents are owned by the target user
+	chown -R "${SANDBOX_UID}:${SANDBOX_GID}" "$HOME/.config" "$HOME/.local" 2>/dev/null || true
 
-    # Re-exec as the target user via gosu
-    exec gosu "$SANDBOX_USER" "$@"
+	# Re-exec as the target user via gosu
+	exec gosu "$SANDBOX_USER" "$@"
 fi
 
 # No SANDBOX_USER set — run as root (backward-compatible)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -55,7 +55,14 @@ if [[ -n "${SANDBOX_USER:-}" ]]; then
 	done
 
 	# Set HOME for the target user
-	export HOME="/home/$SANDBOX_USER"
+    export HOME="/home/$SANDBOX_USER"
+
+    # Grant Docker socket access if mounted
+    if [[ -S /var/run/docker.sock ]]; then
+        docker_gid=$(stat -c '%g' /var/run/docker.sock)
+        groupadd -g "$docker_gid" docker 2>/dev/null || true
+        usermod -aG docker "$SANDBOX_USER" 2>/dev/null || true
+    fi
 fi
 
 # Bridge /data/config → $HOME/.config/opencode so opencode finds its config.

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -8,7 +8,7 @@
  * Options:
  *   --opencode-config-dir <path>  Host config directory (default: ~/.config/opencode,
  *                                  override with OPENCODE_CONFIG_DIR env var).
- *   --sandbox-config-dir <path>   Sandbox config directory (default: ~/.config/opencode-sandbox,
+ *   --sandbox-config-dir <path>   Sandbox config directory (default: ~/.config/opencode/sandbox,
  *                                  override with SANDBOX_CONFIG_DIR env var).
  *   --profiles-config <path>      Path to profiles.toml (default: ~/.config/occonf/profiles.toml,
  *                                  override with OCCONF_PROFILES env var).
@@ -733,7 +733,7 @@ Usage:
 Options:
   --opencode-config-dir <path>  Host config directory (default: ~/.config/opencode,
                                  override with OPENCODE_CONFIG_DIR env var).
-  --sandbox-config-dir <path>   Sandbox config directory (default: ~/.config/opencode-sandbox,
+  --sandbox-config-dir <path>   Sandbox config directory (default: ~/.config/opencode/sandbox,
                                  override with SANDBOX_CONFIG_DIR env var).
   --profiles-config <path>      Path to profiles.toml (default: ~/.config/occonf/profiles.toml,
                                  override with OCCONF_PROFILES env var).
@@ -800,7 +800,7 @@ Options:
     expandHome(
       args["sandbox-config-dir"] ||
         Bun.env.SANDBOX_CONFIG_DIR ||
-        "~/.config/opencode-sandbox",
+        "~/.config/opencode/sandbox",
     ),
   );
   const opencodeDataDir = resolve(

--- a/src/aoe-config.toml
+++ b/src/aoe-config.toml
@@ -12,7 +12,7 @@
 default_tool = "opencode"
 
 [sandbox]
-enabled_by_default = false
+enabled_by_default = true
 default_image = "cubething-occonf-sandbox:latest"
 auto_cleanup = false
 cpu_limit = "4"
@@ -23,4 +23,5 @@ extra_volumes = [
     "{{AGENT_VAULT}}:/data/vault",
     "{{SANDBOX_CONFIG_DIR}}:/data/config",
     "{{OPENCODE_DATA_DIR}}:/data/opencode-data",
+    "/var/run/docker.sock:/var/run/docker.sock",
 ]

--- a/tests/docker/entrypoint.ts
+++ b/tests/docker/entrypoint.ts
@@ -89,6 +89,41 @@ export function entrypointTests() {
     });
   });
 
+  describe("UID/GID collision with default ubuntu user", () => {
+    // ubuntu:24.04 ships with 'ubuntu' at UID 1000 / GID 1000.
+    // The entrypoint must evict it before creating the requested user.
+    const collisionEnv = {
+      SANDBOX_USER: "ada",
+      SANDBOX_GROUP: "agents",
+      SANDBOX_UID: "1000",
+      SANDBOX_GID: "1000",
+    };
+
+    it("creates the requested user at UID 1000 despite ubuntu user collision", async () => {
+      const result = await runEntrypoint(collisionEnv, ["whoami"]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe("ada");
+    });
+
+    it("creates the requested group at GID 1000 despite ubuntu group collision", async () => {
+      const result = await runEntrypoint(collisionEnv, ["id", "-gn"]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe("agents");
+    });
+
+    it("assigns the correct UID", async () => {
+      const result = await runEntrypoint(collisionEnv, ["id", "-u"]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe("1000");
+    });
+
+    it("assigns the correct GID", async () => {
+      const result = await runEntrypoint(collisionEnv, ["id", "-g"]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe("1000");
+    });
+  });
+
   describe("config symlinks", () => {
     it("symlinks $HOME/.config/opencode → /data/config as root", async () => {
       const result = await runEntrypoint({}, [

--- a/tests/e2e/pipeline.test.ts
+++ b/tests/e2e/pipeline.test.ts
@@ -243,8 +243,8 @@ describe("install e2e", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain("Rsync (sandbox) complete");
 
-    // Default SANDBOX_CONFIG_DIR is $HOME/.config/opencode-sandbox
-    const sandboxConfigDir = join(home, ".config", "opencode-sandbox");
+    // Default SANDBOX_CONFIG_DIR is $HOME/.config/opencode/sandbox
+    const sandboxConfigDir = join(home, ".config", "opencode", "sandbox");
     expect(existsSync(join(sandboxConfigDir, "opencode.json"))).toBe(true);
   });
 
@@ -844,7 +844,7 @@ describe("full pipeline e2e", () => {
     expect(existsSync(join(home, ".local", "bin", "vault-sync"))).toBe(true);
 
     // Sandbox config deployed
-    const sandboxConfigDir = join(home, ".config", "opencode-sandbox");
+    const sandboxConfigDir = join(home, ".config", "opencode", "sandbox");
     expect(existsSync(join(sandboxConfigDir, "opencode.json"))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Fixes three bugs preventing AoE sandbox profiles from working:

1. **UID/GID collision** — Ubuntu 24.04 ships with a default `ubuntu` user at UID 1000, which collides with the default SANDBOX_UID/GID. The entrypoint now evicts conflicting users/groups (by both ID and name) before creating the sandbox user, with correct ordering (users before groups) and `groupmod` for name-at-wrong-GID cases.

2. **Docker socket GID collision** — Same eviction pattern applied to the Docker socket group to prevent `groupadd` failures when the target GID is already taken.

3. **AoE bind-mount overrides config symlinks** — AoE bind-mounts `~/.config/opencode/sandbox` (partial config, no `prompts/`) onto `/root/.config/opencode`, overriding the entrypoint's symlink. The new `bridge_config()` function detects bind mounts with `mountpoint -q` and populates them with per-item symlinks from `/data/config`. Also aligns the default `SANDBOX_CONFIG_DIR` to `~/.config/opencode/sandbox` so `install.ts` deploys directly to AoE's mount source.

## Commits

```
ba079ec fix: bridge AoE bind mounts and align sandbox config path
375ab14 add ssh by default, add docker-in-docker support
eb44e84 fix: evict conflicting UID/GID in entrypoint before user creation
```

## Diff summary

```
AGENTS.md                  |   2 +-
 CONTRIBUTING.md            |   4 +-
 docker/Dockerfile          |   5 ++
 docker/entrypoint.sh       | 142 +++++++++++++++++++++++++++++++++++----------
 scripts/install.ts         |   6 +-
 src/aoe-config.toml        |   3 +-
 tests/docker/entrypoint.ts |  35 +++++++++++
 tests/e2e/pipeline.test.ts |   6 +-
 8 files changed, 163 insertions(+), 40 deletions(-)
```