### PR TITLE
feat: add shared convention for agents to file GitHub issues for environment problems

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,9 @@ opencode-config/
 │   ├── opencode.json          #   Core config: model, mode prompts
 │   ├── aoe-config.toml        #   AoE sandbox config template
 │   ├── agents/                #   Subagent definitions (7 agents)
+│   │   ├── _shared/           #     Include fragments shared across agents
+│   │   │   ├── triage.md      #       Triage & notification instructions
+│   │   │   └── env-issues.md  #       Environment problem reporting convention
 │   │   ├── planner.md
 │   │   ├── project-manager.md
 │   │   ├── implementor.md

--- a/src/agents/_shared/env-issues.md
+++ b/src/agents/_shared/env-issues.md
@@ -1,0 +1,20 @@
+## Environment Problem Reporting
+
+When you encounter a missing tool, broken dependency, or misconfigured
+environment in the Docker sandbox or host context that could be fixed
+with an `opencode-config` codebase change, you SHOULD create a GitHub
+issue on `ada-x64/opencode-config` describing the problem.
+
+The issue SHOULD include:
+
+- What tool or dependency was missing or broken
+- What you were trying to do when you encountered the problem
+- The error message or failure mode observed
+- A suggested fix if obvious (e.g., "add `jq` to the Dockerfile")
+
+You SHOULD NOT block on the issue — work around the problem if possible
+and continue with your task. The issue is a side-effect, not a blocker.
+
+Do NOT create duplicate issues. Before filing, check whether an open
+issue already exists for the same problem:
+`gh search issues --repo ada-x64/opencode-config "<tool name>" --state open`

--- a/src/agents/auditor.md
+++ b/src/agents/auditor.md
@@ -214,6 +214,8 @@ Severity uses **roadmap-priority semantics** — a critical audit finding means
 notify_triage({ type: "activity", task: "<owner>/<repo>/<task>", headline: "Audit Complete", body: "• 0 high findings\n• 2 medium warnings", icon: "auditor", emoji: "clean" })
 ```
 
+{{include:agents/_shared/env-issues.md}}
+
 ## What you MUST NOT do
 
 - Run `cargo build`, `npm install`, `pip install`, or any command that modifies

--- a/src/agents/designer.md
+++ b/src/agents/designer.md
@@ -118,6 +118,8 @@ is no task directory for the current work, write the triage entry to
 `$AGENT_VAULT/_misc/activity/` (create if absent) and use `designer`
 as the task name.
 
+{{include:agents/_shared/env-issues.md}}
+
 ## What you MUST NOT do
 
 - Write to any path outside `designs/` and `drafts/` in the vault

--- a/src/agents/implementor.md
+++ b/src/agents/implementor.md
@@ -184,3 +184,5 @@ post-work steps are **mandatory**:
 -->
 
 {{include:agents/_shared/triage.md}}
+
+{{include:agents/_shared/env-issues.md}}

--- a/src/agents/investigate.md
+++ b/src/agents/investigate.md
@@ -127,6 +127,8 @@ there is no task directory for the current work, write the triage entry to
 `$AGENT_VAULT/_misc/activity/` (create if absent) and use
 `investigate` as the task name.
 
+{{include:agents/_shared/env-issues.md}}
+
 ## What you MUST NOT do
 
 - Write to any path outside `notes/` and `drafts/` in the vault

--- a/src/agents/planner.md
+++ b/src/agents/planner.md
@@ -150,6 +150,8 @@ its **Write Mode** instructions. The two post-work steps are **mandatory**:
 
 {{include:agents/_shared/triage.md}}
 
+{{include:agents/_shared/env-issues.md}}
+
 ## What you MUST NOT do
 
 - Write to any path outside the schema file and `$AGENT_VAULT/drafts/`

--- a/src/agents/project-manager.md
+++ b/src/agents/project-manager.md
@@ -184,6 +184,8 @@ follow its **Write Mode** instructions. The two post-work steps are
 > **For cross-repo operations:** If no per-task directory exists, write to
 > `$AGENT_VAULT/_misc/activity/` instead.
 
+{{include:agents/_shared/env-issues.md}}
+
 ## What you MUST NOT do
 
 - Edit source files in any repository

--- a/src/agents/reviewer.md
+++ b/src/agents/reviewer.md
@@ -76,6 +76,8 @@ Pass `reviewer` as the icon **and an outcome semantic key**:
 notify_triage({ type: "activity", task: "<owner>/<repo>/<task>", headline: "Review Complete", body: "• 3 findings, max severity: medium", icon: "reviewer", emoji: "clean" })
 ```
 
+{{include:agents/_shared/env-issues.md}}
+
 ## What you MUST NOT do
 
 - Write to any path outside the review file


### PR DESCRIPTION
## Summary

- Adds `src/agents/_shared/env-issues.md` with a SHOULD-level convention instructing agents to file GitHub issues on `ada-x64/opencode-config` when they encounter missing tools, broken dependencies, or misconfigured environments
- Includes the fragment in all 7 agent prompts via the existing `{{include:...}}` mechanism
- Updates `AGENTS.md` repo layout to document the `_shared/` directory and `env-issues.md` file

## Details

Fix #74 — agents frequently encounter environment problems in the Docker sandbox (missing tools, broken dependencies) but have no convention for tracking them. This PR adds a shared convention file that instructs agents to:

1. File a GitHub issue on `ada-x64/opencode-config` describing the problem
2. Include what was missing, the error, and a suggested fix
3. Check for duplicates before filing
4. NOT block on the issue — work around the problem and continue

The convention uses SHOULD (not MUST) to avoid noise from transient failures.

## Validation

- `bun run build` — passes, includes resolve correctly in both host and sandbox variants
- `bun test` — 305/307 pass (2 pre-existing Docker entrypoint test failures, unrelated)
- `prettier --check` — passes