### PR TITLE
feat: add tone indicator awareness to agent prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -618,6 +618,30 @@ calls fail silently if ntfy is not configured, so they never block agent work.
 
 ---
 
+## Tone Indicators
+
+Users may append **tone indicators** (e.g. `/s`, `/j`, `/gen`) to messages to
+clarify their intent. A shared convention file at
+`src/agents/_shared/tone-indicators.md` teaches all agents to recognise and
+correctly interpret these indicators.
+
+The file is included in every agent prompt (all 7 agents) and every mode prompt
+(build, plan, audit) via the `{{include:}}` mechanism. The build system
+resolves the include at build time — the convention text is inlined into the
+final prompt, not loaded at runtime.
+
+Key rules for agents when a tone indicator is present:
+
+- `/s` (sarcastic) or `/j` (joking): do not act on the literal request;
+  acknowledge the humor and ask what the user actually wants.
+- `/srs` (serious) or `/gen` (genuine): treat the request at full face value.
+- All other indicators: adjust interpretation of the preceding text accordingly.
+
+The full indicator table is defined in the shared file. See
+`src/agents/_shared/tone-indicators.md` for the complete reference.
+
+---
+
 ## Environment Variable Reference
 
 | Variable             | Required            | Description                           | Fallback                            |

--- a/src/agents/_shared/tone-indicators.md
+++ b/src/agents/_shared/tone-indicators.md
@@ -1,0 +1,34 @@
+## Tone Indicators
+
+Users may append **tone indicators** to messages to clarify intent. These are
+short slash-prefixed tags, typically at the end of a sentence or message.
+Interpret them as described below — they override surface-level reading.
+
+| Indicator | Meaning          | Example                               |
+| --------- | ---------------- | ------------------------------------- |
+| `/s`      | sarcastic        | "wow great job /s" → the opposite     |
+| `/srs`    | serious          | "I need this fixed /srs"              |
+| `/j`      | joking           | "just mass-delete everything /j"      |
+| `/hj`     | half-joking      | "we could rewrite it in Rust /hj"     |
+| `/gen`    | genuine          | "this looks really good /gen"         |
+| `/lh`     | light-hearted    | "well that's a fun one /lh"           |
+| `/rh`     | rhetorical       | "what could go wrong /rh"             |
+| `/nm`     | not mad          | "why did this change /nm"             |
+| `/nbh`    | nobody here      | "who wrote this /nbh" → not targeting |
+| `/pos`    | positive tone    | "this is intense /pos"                |
+| `/neg`    | negative tone    | "sure, that works /neg"               |
+| `/p`      | platonic         | "love this code /p"                   |
+| `/r`      | romantic         | (uncommon in dev context)             |
+| `/t`      | teasing          | "oh you would do it that way /t"      |
+| `/ly`     | lyrics / quoting | "never gonna give you up /ly"         |
+| `/lu`     | a little upset   | "this broke again /lu"                |
+| `/nsx`    | non-sexual       | (rarely relevant in dev context)      |
+| `/sx`     | sexual           | (rarely relevant in dev context)      |
+
+When a tone indicator is present:
+
+1. **Adjust your interpretation** of the preceding text accordingly.
+2. **Do not parrot the indicator back** — respond naturally to the intended tone.
+3. **If `/s` or `/j`**, do not act on the literal request; acknowledge the humor
+   or sarcasm and ask what they actually want, if unclear.
+4. **If `/srs` or `/gen`**, treat the request at face value with full sincerity.

--- a/src/agents/auditor.md
+++ b/src/agents/auditor.md
@@ -186,6 +186,8 @@ After writing the audit report, load the `vault-triage` skill and follow its
 - Audit report completed (type: `activity` — include critical/high finding counts and top recommendation)
 -->
 
+{{include:agents/_shared/tone-indicators.md}}
+
 {{include:agents/_shared/triage.md}}
 
 > **For audits:** If no task directory exists for the audited repo, write to

--- a/src/agents/designer.md
+++ b/src/agents/designer.md
@@ -111,6 +111,8 @@ and follow its **Write Mode** instructions. The two post-work steps are
 - Design document written (type: `activity`)
 -->
 
+{{include:agents/_shared/tone-indicators.md}}
+
 {{include:agents/_shared/triage.md}}
 
 **Note:** The designer does not always operate within a task context. If there

--- a/src/agents/implementor.md
+++ b/src/agents/implementor.md
@@ -183,4 +183,6 @@ post-work steps are **mandatory**:
 - Full implementation complete (type: `activity` — include total groups and branch name)
 -->
 
+{{include:agents/_shared/tone-indicators.md}}
+
 {{include:agents/_shared/triage.md}}

--- a/src/agents/investigate.md
+++ b/src/agents/investigate.md
@@ -120,6 +120,8 @@ After writing repo notes, load the `vault-triage` skill and follow its
 - Repo notes written (type: `activity`)
 -->
 
+{{include:agents/_shared/tone-indicators.md}}
+
 {{include:agents/_shared/triage.md}}
 
 **Note:** The investigator does not always operate within a task context. If

--- a/src/agents/planner.md
+++ b/src/agents/planner.md
@@ -148,6 +148,8 @@ its **Write Mode** instructions. The two post-work steps are **mandatory**:
 - GitHub issue created for the schema (type: `activity`)
 -->
 
+{{include:agents/_shared/tone-indicators.md}}
+
 {{include:agents/_shared/triage.md}}
 
 ## What you MUST NOT do

--- a/src/agents/project-manager.md
+++ b/src/agents/project-manager.md
@@ -179,6 +179,8 @@ follow its **Write Mode** instructions. The two post-work steps are
 - Vault cleanup completed (type: `activity` — include archive count)
 -->
 
+{{include:agents/_shared/tone-indicators.md}}
+
 {{include:agents/_shared/triage.md}}
 
 > **For cross-repo operations:** If no per-task directory exists, write to

--- a/src/agents/reviewer.md
+++ b/src/agents/reviewer.md
@@ -64,6 +64,8 @@ After writing the review file, load the `vault-triage` skill and follow its
 - Review completed (type: `activity` — include total finding count and max severity)
 -->
 
+{{include:agents/_shared/tone-indicators.md}}
+
 {{include:agents/_shared/triage.md}}
 
 Pass `reviewer` as the icon **and an outcome semantic key**:

--- a/src/prompts/audit.md
+++ b/src/prompts/audit.md
@@ -123,3 +123,5 @@ notifications via the vault-triage skill.
 - Dispatch `@implementor` — audit mode is read-only and
   does not execute implementation schemas
 - Modify repositories, stage files, or create commits
+
+{{include:agents/_shared/tone-indicators.md}}

--- a/src/prompts/build.md
+++ b/src/prompts/build.md
@@ -262,3 +262,5 @@ notifications via the vault-triage skill.
 - Skip the approval gate between commit groups when using `@implementor`
 - Commit or push without explicit user confirmation
 - Write to the vault directly — vault writes go through the appropriate subagent (exceptions: triage entries written via the `vault-triage` skill, and schema/review status updates when the `auto-impl` skill is loaded)
+
+{{include:agents/_shared/tone-indicators.md}}

--- a/src/prompts/plan.md
+++ b/src/prompts/plan.md
@@ -166,3 +166,5 @@ notifications via the vault-triage skill.
 - Edit files or run state-mutating commands directly (you are in plan mode)
 - Dispatch `@implementor` — implementation starts in build mode (Tab)
 - Skip discussing with the user before dispatching the planner
+
+{{include:agents/_shared/tone-indicators.md}}

--- a/tests/build/build.test.ts
+++ b/tests/build/build.test.ts
@@ -176,6 +176,49 @@ describe("resolveIncludes", () => {
     const result = await readFile(path.join(dir, "agent.md"), "utf-8");
     expect(result).toBe(content);
   });
+
+  it("resolves tone-indicators include in agent and prompt files", async () => {
+    const dir = path.join(tmp, "includes-tone");
+    const srcDir = path.join(tmp, "includes-tone-src");
+    const sharedDir = path.join(srcDir, "agents", "_shared");
+    const agentsDir = path.join(dir, "agents");
+    const promptsDir = path.join(dir, "prompts");
+    await mkdir(sharedDir, { recursive: true });
+    await mkdir(agentsDir, { recursive: true });
+    await mkdir(promptsDir, { recursive: true });
+
+    await writeFile(
+      path.join(sharedDir, "tone-indicators.md"),
+      "## Tone Indicators\n\n| `/s` | sarcastic |\n",
+    );
+
+    await writeFile(
+      path.join(agentsDir, "agent.md"),
+      "# Agent\n\n{{include:agents/_shared/tone-indicators.md}}\n",
+    );
+    await writeFile(
+      path.join(promptsDir, "build.md"),
+      "# Build\n\n{{include:agents/_shared/tone-indicators.md}}\n",
+    );
+
+    resolveIncludes(dir, srcDir);
+
+    const agentResult = await readFile(
+      path.join(agentsDir, "agent.md"),
+      "utf-8",
+    );
+    expect(agentResult).toContain("## Tone Indicators");
+    expect(agentResult).toContain("sarcastic");
+    expect(agentResult).not.toContain("{{include:");
+
+    const promptResult = await readFile(
+      path.join(promptsDir, "build.md"),
+      "utf-8",
+    );
+    expect(promptResult).toContain("## Tone Indicators");
+    expect(promptResult).toContain("sarcastic");
+    expect(promptResult).not.toContain("{{include:");
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Create shared convention file at `src/agents/_shared/tone-indicators.md` teaching agents to recognise and interpret tone indicators (`/s`, `/j`, `/gen`, `/srs`, etc.)
- Include it in all 7 agent prompts and all 3 mode prompts via the `{{include:}}` mechanism
- Add documentation to `AGENTS.md` and a build test verifying include resolution

## Problem

Agents had no awareness of tone indicators. When a user writes "yeah that is great /s", the agent takes it at face value instead of recognising the sarcasm.

## Changes

| File | Change |
|------|--------|
| `src/agents/_shared/tone-indicators.md` | **New** — shared include fragment with indicator table and interpretation rules |
| `src/agents/*.md` (7 files) | Add `{{include:agents/_shared/tone-indicators.md}}` before triage include |
| `src/prompts/*.md` (3 files) | Add `{{include:agents/_shared/tone-indicators.md}}` at end of file |
| `AGENTS.md` | Document tone indicator convention in new section |
| `tests/build/build.test.ts` | Add test verifying include resolves in both agent and prompt files |

## Validation

- `bun run build` — ✅ all includes resolve in all 10 output files
- `bun test` — ✅ 37/37 build tests pass (including new tone-indicator test)

Fixes #78