### PR TITLE
feat: add tags, estimate, and multi-repo support to vault frontmatter

### DIFF
--- a/src/tools/fm/_lib.ts
+++ b/src/tools/fm/_lib.ts
@@ -84,6 +84,25 @@ export function fmWrite(content: string, key: string, value: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Flow-array parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a YAML flow-array value like `[a, b, c]` into a string array.
+ * Returns `null` if the value is not a flow array (i.e. a plain scalar).
+ */
+export function parseFlowArray(value: string): string[] | null {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return null;
+  const inner = trimmed.slice(1, -1).trim();
+  if (inner === "") return [];
+  return inner
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s !== "");
+}
+
+// ---------------------------------------------------------------------------
 // Validation enums (exported for use by vault_lint)
 // ---------------------------------------------------------------------------
 
@@ -114,10 +133,28 @@ export const PRIORITY_VALUES = [
   "🟣 non-work",
 ];
 
+/** Valid estimate values (t-shirt sizes). */
+export const ESTIMATE_VALUES = ["XS", "S", "M", "L", "XL"];
+
+/** Soft vocabulary for task tags — unknown tags produce warnings, not errors. */
+export const TAG_VOCABULARY = [
+  "ci",
+  "bug",
+  "feature",
+  "enhancement",
+  "refactor",
+  "docs",
+  "tooling",
+  "infra",
+  "test",
+  "security",
+  "release",
+];
+
 /**
  * Validate a frontmatter key/value pair for a given file path.
  *
- * Only validates `status` and `priority` keys for files inside `$AGENT_VAULT`.
+ * Validates `status`, `priority`, `estimate`, `tags`, and `repo` keys for files inside `$AGENT_VAULT`.
  * Returns an error message string if invalid, `null` if valid or not applicable.
  */
 export function validateFmValue(
@@ -125,8 +162,9 @@ export function validateFmValue(
   key: string,
   value: string,
 ): string | null {
-  // Only validate status and priority keys
-  if (key !== "status" && key !== "priority") return null;
+  // Only validate known keys
+  if (!["status", "priority", "estimate", "tags", "repo"].includes(key))
+    return null;
 
   // Read AGENT_VAULT — skip validation if unset or file is outside vault
   const vault = process.env.AGENT_VAULT;
@@ -142,6 +180,39 @@ export function validateFmValue(
     if (!relPath.startsWith("tasks/")) return null;
     if (!PRIORITY_VALUES.includes(value)) {
       return `invalid priority '${value}' — valid values: ${PRIORITY_VALUES.join(", ")}`;
+    }
+    return null;
+  }
+
+  if (key === "estimate") {
+    // Estimate validation only applies to task schemas
+    if (!relPath.startsWith("tasks/")) return null;
+    if (!ESTIMATE_VALUES.includes(value)) {
+      return `invalid estimate '${value}' — valid values: ${ESTIMATE_VALUES.join(", ")}`;
+    }
+    return null;
+  }
+
+  if (key === "tags") {
+    // Tags use soft vocabulary — fm_write never rejects.
+    // Lint handles vocabulary warnings.
+    return null;
+  }
+
+  if (key === "repo") {
+    const repoPattern = /^[^/\s]+\/[^/\s]+$/;
+    const arr = parseFlowArray(value);
+    if (arr !== null) {
+      for (const elem of arr) {
+        if (!repoPattern.test(elem)) {
+          return `invalid repo element '${elem}' — expected 'owner/repo' format`;
+        }
+      }
+      return null;
+    }
+    // Scalar — validate format
+    if (!repoPattern.test(value)) {
+      return `invalid repo '${value}' — expected 'owner/repo' format`;
     }
     return null;
   }

--- a/src/tools/vault/find.ts
+++ b/src/tools/vault/find.ts
@@ -1,6 +1,7 @@
 import { tool } from "@opencode-ai/plugin";
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
+import { parseFlowArray } from "../fm/_lib";
 
 // Parse all key: value pairs from the YAML frontmatter block
 function parseFrontmatter(content: string): Record<string, string> {
@@ -180,7 +181,13 @@ export default tool({
           try {
             const content = await readFile(f, "utf-8");
             const fm = parseFrontmatter(content);
-            return fm["repo"] === args.repo ? f : null;
+            const repoVal = fm["repo"];
+            if (!repoVal) return null;
+            const arr = parseFlowArray(repoVal);
+            if (arr !== null) {
+              return arr.includes(args.repo!) ? f : null;
+            }
+            return repoVal === args.repo ? f : null;
           } catch {
             return null;
           }

--- a/src/tools/vault/lint.ts
+++ b/src/tools/vault/lint.ts
@@ -2,7 +2,14 @@
 import { tool } from "@opencode-ai/plugin";
 import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
-import { PRIORITY_VALUES, REVIEW_STATUSES, STATUS_ENUMS } from "../fm/_lib";
+import {
+  PRIORITY_VALUES,
+  REVIEW_STATUSES,
+  STATUS_ENUMS,
+  ESTIMATE_VALUES,
+  TAG_VOCABULARY,
+  parseFlowArray,
+} from "../fm/_lib";
 
 // ---------------------------------------------------------------------------
 // Frontmatter helpers
@@ -33,7 +40,7 @@ function lintSchema(content: string, relPath: string): string[] {
     return errors;
   }
 
-  for (const field of ["repo", "date", "task"]) {
+  for (const field of ["repo", "date", "task", "tags", "estimate"]) {
     if (!new RegExp(`^${field}:`, "m").test(block)) {
       errors.push(`${relPath}: missing '${field}' in frontmatter`);
     }
@@ -66,6 +73,55 @@ function lintSchema(content: string, relPath: string): string[] {
 
   if (!/^issue:/m.test(block)) {
     errors.push(`${relPath}: warning: missing 'issue' in frontmatter`);
+  }
+
+  const estimateMatch = block.match(/^estimate:\s*(.+)$/m);
+  if (estimateMatch) {
+    const estimate = estimateMatch[1]!.trim();
+    if (!ESTIMATE_VALUES.includes(estimate)) {
+      errors.push(
+        `${relPath}: invalid estimate value: '${estimate}' (expected: ${ESTIMATE_VALUES.join(", ")})`,
+      );
+    }
+  }
+
+  const tagsMatch = block.match(/^tags:\s*(.+)$/m);
+  if (tagsMatch) {
+    const tagsRaw = tagsMatch[1]!.trim();
+    const parsed = parseFlowArray(tagsRaw);
+    if (parsed === null) {
+      errors.push(
+        `${relPath}: tags must be a flow array (e.g. [ci, bug]), got: '${tagsRaw}'`,
+      );
+    } else {
+      for (const tag of parsed) {
+        if (!TAG_VOCABULARY.includes(tag)) {
+          errors.push(
+            `${relPath}: warning: unknown tag '${tag}' (known: ${TAG_VOCABULARY.join(", ")})`,
+          );
+        }
+      }
+    }
+  }
+
+  const repoMatch = block.match(/^repo:\s*(.+)$/m);
+  if (repoMatch) {
+    const repoRaw = repoMatch[1]!.trim();
+    const repoPattern = /^[^/\s]+\/[^/\s]+$/;
+    const arr = parseFlowArray(repoRaw);
+    if (arr !== null) {
+      for (const elem of arr) {
+        if (!repoPattern.test(elem)) {
+          errors.push(
+            `${relPath}: invalid repo element '${elem}' — expected 'owner/repo' format`,
+          );
+        }
+      }
+    } else if (!repoPattern.test(repoRaw)) {
+      errors.push(
+        `${relPath}: invalid repo '${repoRaw}' — expected 'owner/repo' format`,
+      );
+    }
   }
 
   if (!/^# /m.test(content)) {
@@ -118,6 +174,45 @@ function lintReview(content: string, relPath: string): string[] {
 
   if (!/^## Verdict:/m.test(content)) {
     errors.push(`${relPath}: missing ## Verdict: section`);
+  }
+
+  // Warn about missing tags and estimate (not required for reviews, just advisory)
+  if (!/^tags:/m.test(block)) {
+    errors.push(`${relPath}: warning: missing 'tags' in frontmatter`);
+  }
+  if (!/^estimate:/m.test(block)) {
+    errors.push(`${relPath}: warning: missing 'estimate' in frontmatter`);
+  }
+
+  // Validate tags format and vocabulary if present
+  const reviewTagsMatch = block.match(/^tags:\s*(.+)$/m);
+  if (reviewTagsMatch) {
+    const tagsRaw = reviewTagsMatch[1]!.trim();
+    const parsed = parseFlowArray(tagsRaw);
+    if (parsed === null) {
+      errors.push(
+        `${relPath}: tags must be a flow array (e.g. [ci, bug]), got: '${tagsRaw}'`,
+      );
+    } else {
+      for (const tag of parsed) {
+        if (!TAG_VOCABULARY.includes(tag)) {
+          errors.push(
+            `${relPath}: warning: unknown tag '${tag}' (known: ${TAG_VOCABULARY.join(", ")})`,
+          );
+        }
+      }
+    }
+  }
+
+  // Validate estimate format if present
+  const reviewEstimateMatch = block.match(/^estimate:\s*(.+)$/m);
+  if (reviewEstimateMatch) {
+    const estimate = reviewEstimateMatch[1]!.trim();
+    if (!ESTIMATE_VALUES.includes(estimate)) {
+      errors.push(
+        `${relPath}: invalid estimate value: '${estimate}' (expected: ${ESTIMATE_VALUES.join(", ")})`,
+      );
+    }
   }
 
   // Check each ### N. issue block for **Severity:** and **Category:**

--- a/src/vault/_misc/fileClasses/Task.md
+++ b/src/vault/_misc/fileClasses/Task.md
@@ -45,6 +45,12 @@ savedViews:
       - id: Task____priority
         name: priority
         query: ""
+      - id: Task____tags
+        name: tags
+        query: ""
+      - id: Task____estimate
+        name: estimate
+        query: ""
     columns:
       - id: Task____file
         name: file
@@ -57,15 +63,15 @@ savedViews:
       - id: Task____issue
         name: issue
         hidden: false
-        position: 5
+        position: 7
       - id: Task____branch
         name: branch
         hidden: false
-        position: 6
+        position: 8
       - id: Task____date
         name: date
         hidden: false
-        position: 7
+        position: 9
       - id: Task____status
         name: status
         hidden: false
@@ -78,6 +84,14 @@ savedViews:
         name: priority
         hidden: false
         position: 4
+      - id: Task____estimate
+        name: estimate
+        hidden: false
+        position: 5
+      - id: Task____tags
+        name: tags
+        hidden: false
+        position: 6
   - name: active
     children: []
     sorters:
@@ -130,6 +144,14 @@ savedViews:
         name: repo
         query: ""
         customFilter: ""
+      - id: Task____tags
+        name: tags
+        query: ""
+        customFilter: ""
+      - id: Task____estimate
+        name: estimate
+        query: ""
+        customFilter: ""
     columns:
       - id: Task____file
         name: file
@@ -142,15 +164,15 @@ savedViews:
       - id: Task____issue
         name: issue
         hidden: false
-        position: 5
+        position: 7
       - id: Task____branch
         name: branch
         hidden: true
-        position: 7
+        position: 9
       - id: Task____date
         name: date
         hidden: true
-        position: 6
+        position: 8
       - id: Task____status
         name: status
         hidden: false
@@ -163,13 +185,21 @@ savedViews:
         name: repo
         hidden: false
         position: 4
+      - id: Task____estimate
+        name: estimate
+        hidden: false
+        position: 5
+      - id: Task____tags
+        name: tags
+        hidden: false
+        position: 6
 fields:
   - name: task
     type: Input
     id: task
     options: {}
   - name: repo
-    type: Input
+    type: Multi
     id: repo
     options: {}
   - name: status
@@ -194,6 +224,17 @@ fields:
         "2": 🟡 medium
         "3": 🟢 low
         "4": 🟣 non-work
+  - name: estimate
+    type: Select
+    id: estimate
+    options:
+      sourceType: ValuesList
+      valuesList:
+        "0": XS
+        "1": S
+        "2": M
+        "3": L
+        "4": XL
   - name: date
     type: Date
     id: date
@@ -206,6 +247,10 @@ fields:
     type: Input
     id: issue
     options: {}
+  - name: tags
+    type: Multi
+    id: tags
+    options: {}
 filesPaths:
   - tasks
 bookmarksGroups:
@@ -217,6 +262,8 @@ fieldsOrder:
   - date
   - status
   - priority
+  - estimate
   - repo
-version: "2.8"
+  - tags
+version: "2.9"
 ---

--- a/src/vault/_misc/templates/schema.md
+++ b/src/vault/_misc/templates/schema.md
@@ -26,17 +26,17 @@ date: YYYY-MM-DD
 
 ### Frontmatter fields
 
-| Field      | Description                                                                      |
-| ---------- | -------------------------------------------------------------------------------- |
-| `repo`     | `<owner>/<repo>` identifier. Also accepts flow array `[owner/repo1, owner/repo2]` for multi-repo tasks. |
+| Field      | Description                                                                                                                                                         |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `repo`     | `<owner>/<repo>` identifier. Also accepts flow array `[owner/repo1, owner/repo2]` for multi-repo tasks.                                                             |
 | `tags`     | Category tags as flow array (e.g. `[ci, bug]`). Known: ci, bug, feature, enhancement, refactor, docs, tooling, infra, test, security, release. Custom tags allowed. |
-| `estimate` | Effort estimate: `XS`, `S`, `M`, `L`, `XL`.                                     |
-| `issue`    | GitHub issue link (e.g. `[#1](https://github.com/owner/repo/issues/1)`) or blank |
-| `branch`   | Target branch name                                                               |
-| `status`   | `📋 todo` / `🔨 in-progress` / `🔍 in-review` / `✅ complete` / `🚫 closed`      |
-| `task`     | Task name (kebab-case, matches directory name under `tasks/`)                    |
-| `priority` | `🔥 critical` / `🔴 high` / `🟡 medium` / `🟢 low` / `🟣 non-work`               |
-| `date`     | Creation date (YYYY-MM-DD)                                                       |
+| `estimate` | Effort estimate: `XS`, `S`, `M`, `L`, `XL`.                                                                                                                         |
+| `issue`    | GitHub issue link (e.g. `[#1](https://github.com/owner/repo/issues/1)`) or blank                                                                                    |
+| `branch`   | Target branch name                                                                                                                                                  |
+| `status`   | `📋 todo` / `🔨 in-progress` / `🔍 in-review` / `✅ complete` / `🚫 closed`                                                                                         |
+| `task`     | Task name (kebab-case, matches directory name under `tasks/`)                                                                                                       |
+| `priority` | `🔥 critical` / `🔴 high` / `🟡 medium` / `🟢 low` / `🟣 non-work`                                                                                                  |
+| `date`     | Creation date (YYYY-MM-DD)                                                                                                                                          |
 
 ## Problem
 

--- a/src/vault/_misc/templates/schema.md
+++ b/src/vault/_misc/templates/schema.md
@@ -11,6 +11,8 @@ Every schema starts with YAML frontmatter followed by an H1 title:
 ```markdown
 ---
 repo: <owner>/<repo>
+tags: [<category tags>]
+estimate: <XS|S|M|L|XL>
 issue: <link or blank>
 branch: <branch-name>
 status: 📋 todo
@@ -26,7 +28,9 @@ date: YYYY-MM-DD
 
 | Field      | Description                                                                      |
 | ---------- | -------------------------------------------------------------------------------- |
-| `repo`     | `<owner>/<repo>` identifier                                                      |
+| `repo`     | `<owner>/<repo>` identifier. Also accepts flow array `[owner/repo1, owner/repo2]` for multi-repo tasks. |
+| `tags`     | Category tags as flow array (e.g. `[ci, bug]`). Known: ci, bug, feature, enhancement, refactor, docs, tooling, infra, test, security, release. Custom tags allowed. |
+| `estimate` | Effort estimate: `XS`, `S`, `M`, `L`, `XL`.                                     |
 | `issue`    | GitHub issue link (e.g. `[#1](https://github.com/owner/repo/issues/1)`) or blank |
 | `branch`   | Target branch name                                                               |
 | `status`   | `📋 todo` / `🔨 in-progress` / `🔍 in-review` / `✅ complete` / `🚫 closed`      |

--- a/tests/tools/frontmatter.test.ts
+++ b/tests/tools/frontmatter.test.ts
@@ -494,11 +494,7 @@ describe("validateFmValue for repo", () => {
 
   it("rejects repo with spaces", () => {
     expect(
-      validateFmValue(
-        `${vaultTmp}/tasks/t/schema.md`,
-        "repo",
-        "owner/ repo",
-      ),
+      validateFmValue(`${vaultTmp}/tasks/t/schema.md`, "repo", "owner/ repo"),
     ).toMatch(/invalid repo/);
   });
 });

--- a/tests/tools/frontmatter.test.ts
+++ b/tests/tools/frontmatter.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "os";
 import path from "path";
 import fm_read from "../../src/tools/fm/read";
 import fm_write from "../../src/tools/fm/write";
+import { parseFlowArray, validateFmValue } from "../../src/tools/fm/_lib";
 import { execute_tool } from "./_lib";
 
 const SAMPLE_DOC = `---
@@ -287,7 +288,7 @@ describe("fm_write validation", () => {
     }
   });
 
-  it("skips validation for non-status/priority keys (e.g. 'repo')", async () => {
+  it("validates repo format for task files (accepts valid owner/repo)", async () => {
     const file = await makeVaultFile("tasks/owner/repo/mytask7/schema.md");
     const result = await execute_tool(fm_write, {
       file,
@@ -363,5 +364,155 @@ describe("fm_write validation", () => {
     });
     // Key doesn't exist in frontmatter → fmWrite is a no-op → no validation
     expect(result).not.toMatch(/^Error:/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseFlowArray tests
+// ---------------------------------------------------------------------------
+
+describe("parseFlowArray", () => {
+  it("parses a multi-element array", () => {
+    expect(parseFlowArray("[a, b, c]")).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns null for a scalar", () => {
+    expect(parseFlowArray("foo")).toBeNull();
+  });
+
+  it("parses an empty array", () => {
+    expect(parseFlowArray("[]")).toEqual([]);
+  });
+
+  it("parses a single-element array", () => {
+    expect(parseFlowArray("[single]")).toEqual(["single"]);
+  });
+
+  it("handles whitespace around brackets", () => {
+    expect(parseFlowArray("  [ a , b ]  ")).toEqual(["a", "b"]);
+  });
+
+  it("filters out empty entries from trailing comma", () => {
+    expect(parseFlowArray("[a, b, ]")).toEqual(["a", "b"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateFmValue tests for estimate, tags, repo
+// ---------------------------------------------------------------------------
+
+describe("validateFmValue for estimate", () => {
+  it("accepts valid estimate 'M'", () => {
+    expect(
+      validateFmValue(`${vaultTmp}/tasks/t/schema.md`, "estimate", "M"),
+    ).toBeNull();
+  });
+
+  it("accepts valid estimate 'XS'", () => {
+    expect(
+      validateFmValue(`${vaultTmp}/tasks/t/schema.md`, "estimate", "XS"),
+    ).toBeNull();
+  });
+
+  it("accepts valid estimate 'XL'", () => {
+    expect(
+      validateFmValue(`${vaultTmp}/tasks/t/schema.md`, "estimate", "XL"),
+    ).toBeNull();
+  });
+
+  it("rejects invalid estimate 'XXL'", () => {
+    expect(
+      validateFmValue(`${vaultTmp}/tasks/t/schema.md`, "estimate", "XXL"),
+    ).toMatch(/invalid estimate/);
+  });
+
+  it("rejects lowercase estimate 'm'", () => {
+    expect(
+      validateFmValue(`${vaultTmp}/tasks/t/schema.md`, "estimate", "m"),
+    ).toMatch(/invalid estimate/);
+  });
+
+  it("skips estimate validation for non-task files", () => {
+    expect(
+      validateFmValue(`${vaultTmp}/audits/a/b.md`, "estimate", "INVALID"),
+    ).toBeNull();
+  });
+});
+
+describe("validateFmValue for tags", () => {
+  it("accepts known tags (always returns null)", () => {
+    expect(
+      validateFmValue(`${vaultTmp}/tasks/t/schema.md`, "tags", "[ci, bug]"),
+    ).toBeNull();
+  });
+
+  it("accepts unknown tags (soft vocabulary — no write-time error)", () => {
+    expect(
+      validateFmValue(
+        `${vaultTmp}/tasks/t/schema.md`,
+        "tags",
+        "[ci, custom-tag]",
+      ),
+    ).toBeNull();
+  });
+
+  it("accepts empty tags array", () => {
+    expect(
+      validateFmValue(`${vaultTmp}/tasks/t/schema.md`, "tags", "[]"),
+    ).toBeNull();
+  });
+});
+
+describe("validateFmValue for repo", () => {
+  it("accepts scalar owner/repo", () => {
+    expect(
+      validateFmValue(`${vaultTmp}/tasks/t/schema.md`, "repo", "owner/repo"),
+    ).toBeNull();
+  });
+
+  it("accepts flow array of repos", () => {
+    expect(
+      validateFmValue(
+        `${vaultTmp}/tasks/t/schema.md`,
+        "repo",
+        "[owner/a, owner/b]",
+      ),
+    ).toBeNull();
+  });
+
+  it("rejects malformed repo in array", () => {
+    expect(
+      validateFmValue(`${vaultTmp}/tasks/t/schema.md`, "repo", "[malformed]"),
+    ).toMatch(/invalid repo/);
+  });
+
+  it("rejects malformed scalar repo", () => {
+    expect(
+      validateFmValue(`${vaultTmp}/tasks/t/schema.md`, "repo", "no-slash"),
+    ).toMatch(/invalid repo/);
+  });
+
+  it("rejects repo with spaces", () => {
+    expect(
+      validateFmValue(
+        `${vaultTmp}/tasks/t/schema.md`,
+        "repo",
+        "owner/ repo",
+      ),
+    ).toMatch(/invalid repo/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fm_read flow-array test
+// ---------------------------------------------------------------------------
+
+describe("fm_read flow-array", () => {
+  it("reads flow array value as raw string", async () => {
+    const doc = `---\nrepo: [owner/a, owner/b]\n---\n\n# Title\n`;
+    const file = path.join(tmp, "flow-array.md");
+    await writeFile(file, doc);
+    const result = await execute_tool(fm_read, { file, key: "repo" });
+    expect(result).toBe("[owner/a, owner/b]");
   });
 });

--- a/tests/tools/vault-lint.test.ts
+++ b/tests/tools/vault-lint.test.ts
@@ -16,6 +16,8 @@ const VALID_SCHEMA = `---
 status: 📋 todo
 repo: lint-owner/lint-repo
 task: task-valid
+tags: [ci, bug]
+estimate: M
 date: 2026-01-01
 priority: 🟡 medium
 issue: "[#1](https://github.com/lint-owner/lint-repo/issues/1)"

--- a/tests/tools/vault-lint.test.ts
+++ b/tests/tools/vault-lint.test.ts
@@ -58,11 +58,135 @@ const BAD_STATUS_SCHEMA = `---
 status: wip
 repo: lint-owner/lint-repo
 task: task-bad-status
+tags: [ci]
+estimate: M
 date: 2026-01-01
 issue: "[#2](https://github.com/lint-owner/lint-repo/issues/2)"
 ---
 
 # Bad Status Task
+
+## Problem
+
+Problem.
+
+## Approach
+
+Approach.
+
+## Todos
+
+- [ ] item
+
+## Files changed
+
+- file.ts
+`;
+
+// Schema missing tags field
+const MISSING_TAGS_SCHEMA = `---
+status: 📋 todo
+repo: lint-owner/lint-repo
+task: task-no-tags
+estimate: M
+date: 2026-01-01
+priority: 🟡 medium
+issue: "[#3](https://github.com/lint-owner/lint-repo/issues/3)"
+---
+
+# Missing Tags Task
+
+## Problem
+
+Problem.
+
+## Approach
+
+Approach.
+
+## Todos
+
+- [ ] item
+
+## Files changed
+
+- file.ts
+`;
+
+// Schema missing estimate field
+const MISSING_ESTIMATE_SCHEMA = `---
+status: 📋 todo
+repo: lint-owner/lint-repo
+task: task-no-estimate
+tags: [ci]
+date: 2026-01-01
+priority: 🟡 medium
+issue: "[#4](https://github.com/lint-owner/lint-repo/issues/4)"
+---
+
+# Missing Estimate Task
+
+## Problem
+
+Problem.
+
+## Approach
+
+Approach.
+
+## Todos
+
+- [ ] item
+
+## Files changed
+
+- file.ts
+`;
+
+// Schema with invalid estimate value
+const BAD_ESTIMATE_SCHEMA = `---
+status: 📋 todo
+repo: lint-owner/lint-repo
+task: task-bad-estimate
+tags: [ci]
+estimate: XXL
+date: 2026-01-01
+priority: 🟡 medium
+issue: "[#5](https://github.com/lint-owner/lint-repo/issues/5)"
+---
+
+# Bad Estimate Task
+
+## Problem
+
+Problem.
+
+## Approach
+
+Approach.
+
+## Todos
+
+- [ ] item
+
+## Files changed
+
+- file.ts
+`;
+
+// Schema with unknown tag (should warn, not error on required)
+const UNKNOWN_TAG_SCHEMA = `---
+status: 📋 todo
+repo: lint-owner/lint-repo
+task: task-unknown-tag
+tags: [ci, custom-foo]
+estimate: S
+date: 2026-01-01
+priority: 🟡 medium
+issue: "[#6](https://github.com/lint-owner/lint-repo/issues/6)"
+---
+
+# Unknown Tag Task
 
 ## Problem
 
@@ -89,12 +213,32 @@ beforeAll(async () => {
   await mkdir(path.join(base, "task-valid"), { recursive: true });
   await mkdir(path.join(base, "task-invalid"), { recursive: true });
   await mkdir(path.join(base, "task-bad-status"), { recursive: true });
+  await mkdir(path.join(base, "task-no-tags"), { recursive: true });
+  await mkdir(path.join(base, "task-no-estimate"), { recursive: true });
+  await mkdir(path.join(base, "task-bad-estimate"), { recursive: true });
+  await mkdir(path.join(base, "task-unknown-tag"), { recursive: true });
 
   await writeFile(path.join(base, "task-valid", "schema.md"), VALID_SCHEMA);
   await writeFile(path.join(base, "task-invalid", "schema.md"), INVALID_SCHEMA);
   await writeFile(
     path.join(base, "task-bad-status", "schema.md"),
     BAD_STATUS_SCHEMA,
+  );
+  await writeFile(
+    path.join(base, "task-no-tags", "schema.md"),
+    MISSING_TAGS_SCHEMA,
+  );
+  await writeFile(
+    path.join(base, "task-no-estimate", "schema.md"),
+    MISSING_ESTIMATE_SCHEMA,
+  );
+  await writeFile(
+    path.join(base, "task-bad-estimate", "schema.md"),
+    BAD_ESTIMATE_SCHEMA,
+  );
+  await writeFile(
+    path.join(base, "task-unknown-tag", "schema.md"),
+    UNKNOWN_TAG_SCHEMA,
   );
 
   process.env.AGENT_VAULT = vault;
@@ -190,5 +334,50 @@ describe("vault_lint", () => {
     } finally {
       process.env.AGENT_VAULT = vault;
     }
+  });
+
+  // ── Tags/estimate lint rules ──────────────────────────────────────────────
+
+  it("reports missing tags as an error", async () => {
+    const result = await execute_tool(vault_lint, {
+      schemas_only: true,
+      filter: "lint-owner/lint-repo/task-no-tags",
+    });
+    expect(result).toMatch(/missing 'tags'/);
+  });
+
+  it("reports missing estimate as an error", async () => {
+    const result = await execute_tool(vault_lint, {
+      schemas_only: true,
+      filter: "lint-owner/lint-repo/task-no-estimate",
+    });
+    expect(result).toMatch(/missing 'estimate'/);
+  });
+
+  it("reports invalid estimate value", async () => {
+    const result = await execute_tool(vault_lint, {
+      schemas_only: true,
+      filter: "lint-owner/lint-repo/task-bad-estimate",
+    });
+    expect(result).toMatch(/invalid estimate value.*XXL/);
+  });
+
+  it("reports unknown tags as warnings", async () => {
+    const result = await execute_tool(vault_lint, {
+      schemas_only: true,
+      filter: "lint-owner/lint-repo/task-unknown-tag",
+    });
+    expect(result).toMatch(/warning.*unknown tag.*custom-foo/);
+    // Should NOT report tags as missing (they are present)
+    expect(result).not.toMatch(/missing 'tags'/);
+  });
+
+  it("invalid schema also reports missing tags and estimate", async () => {
+    const result = await execute_tool(vault_lint, {
+      schemas_only: true,
+      filter: "lint-owner/lint-repo/task-invalid",
+    });
+    expect(result).toMatch(/missing 'tags'/);
+    expect(result).toMatch(/missing 'estimate'/);
   });
 });


### PR DESCRIPTION
## Summary

Fix #73 — add `tags`, `estimate`, and multi-repo `repo` support to vault frontmatter with lint validation and Obsidian fileClass updates.

- **`tags`** — flow array field (`[ci, bug, tooling]`) with soft vocabulary (unknown tags warned by lint, not rejected by `fm_write`)
- **`estimate`** — t-shirt size enum (`XS`, `S`, `M`, `L`, `XL`) with strict validation
- **`repo`** — now accepts both scalar `owner/repo` and flow array `[owner/a, owner/b]` for cross-repo tasks

## Changes

### Core (`src/tools/fm/_lib.ts`)
- Add `parseFlowArray()` helper for YAML flow-array parsing
- Add `ESTIMATE_VALUES` and `TAG_VOCABULARY` constants
- Extend `validateFmValue()` to validate `estimate`, `tags`, and `repo` keys

### Lint (`src/tools/vault/lint.ts`)
- `tags` and `estimate` are now required fields on schemas (error if missing)
- Validate estimate enum values, tags flow-array format, and tag vocabulary (warnings for unknown)
- Validate repo format for both scalar and flow-array values
- Add review warnings for missing `tags` and `estimate`

### Find (`src/tools/vault/find.ts`)
- Repo filter now checks membership in parsed flow arrays

### Obsidian (`src/vault/_misc/fileClasses/Task.md`)
- Convert `repo` from `Input` to `Multi` type
- Add `estimate` (Select with XS/S/M/L/XL values) and `tags` (Multi) fields
- Update `fieldsOrder` and both saved views with new filter/column entries
- Bump version 2.8 → 2.9

### Template (`src/vault/_misc/templates/schema.md`)
- Add `tags` and `estimate` to frontmatter example
- Document flow-array repo format and tag vocabulary

### Tests
- 26 new tests for `parseFlowArray`, `validateFmValue` (estimate/tags/repo), flow-array `fmRead`, and vault-lint rules
- All 151 tool tests pass

---
*Posted by **auto-impl***