### PR TITLE
feat: split in-review into local-review and peer-review statuses

### DIFF
--- a/src/agents/implementor.md
+++ b/src/agents/implementor.md
@@ -56,7 +56,7 @@ and prints the updated working path (see Behavior §3 below).
 - **Read-write:** task directory under `$AGENT_VAULT/tasks/` (for status updates)
 - **Build tools:** pre-approved (make, uv, python, cargo, pip, npm, etc.)
 - **Git staging:** pre-approved (`git add`)
-- **GitHub issue label transitions:** pre-approved (`gh issue edit` for `in-progress` label only; `review-ready` is set manually)
+- **GitHub issue label transitions:** pre-approved (`gh issue edit` for `in-progress` and `local-review` labels; `peer-review` is set when PR is pushed)
 - **Git commit/push, other gh mutations:** NOT pre-approved — always prompt
 
 ## Behavior
@@ -116,11 +116,11 @@ and prints the updated working path (see Behavior §3 below).
   ```
   This is best-effort and never blocks the startup sequence.
 - **After final commit group:** When all commit groups are complete and validated,
-  update the schema status to `🔍 in-review`:
+  update the schema status to `🔍 local-review`:
   ```
-  fm_write({ file: schema_file, key: "status", value: "🔍 in-review" })
+  fm_write({ file: schema_file, key: "status", value: "🔍 local-review" })
   ```
-- **After setting status `🔍 in-review`:** Remove the `in-progress` label and add the `review-ready` label on the linked GitHub issue (skip if vault-only or blank):
+- **After setting status `🔍 local-review`:** Remove the `in-progress` label and add the `local-review` label on the linked GitHub issue (skip if vault-only or blank):
   ```
   issue_field = fm_read({ file: schema_file, key: "issue" })
   repo_slug = fm_read({ file: schema_file, key: "repo" })
@@ -128,7 +128,7 @@ and prints the updated working path (see Behavior §3 below).
   If `issue_field` is non-empty and does not start with `local-`:
   ```bash
   _issue_num="$(echo "$issue_field" | grep -oP '#\K[0-9]+')"
-  gh issue edit "$_issue_num" -R "$repo_slug" --remove-label "in-progress" --add-label "review-ready" 2>/dev/null || true
+  gh issue edit "$_issue_num" -R "$repo_slug" --remove-label "in-progress" --add-label "local-review" 2>/dev/null || true
   ```
   This is best-effort and never blocks the completion sequence.
 - **Also on completion:** Post a completion comment on the linked GitHub issue (skip if vault-only or blank).

--- a/src/agents/project-manager.md
+++ b/src/agents/project-manager.md
@@ -159,11 +159,12 @@ The handoff point is the moment `@planner` writes the issue URL into the schema 
 
 ## Label Setup (one-time per repo)
 
-The `in-progress` and `review-ready` labels must exist on each repo before implementors can apply them. PM creates them as a one-time setup:
+The `in-progress`, `local-review`, and `peer-review` labels must exist on each repo before implementors can apply them. PM creates them as a one-time setup:
 
 ```bash
 gh label create "in-progress" --color "fbca04" -R <owner>/<repo> 2>/dev/null || true
-gh label create "review-ready" --color "0075ca" -R <owner>/<repo> 2>/dev/null || true
+gh label create "local-review" --color "0075ca" -R <owner>/<repo> 2>/dev/null || true
+gh label create "peer-review" --color "5319e7" -R <owner>/<repo> 2>/dev/null || true
 ```
 
 ## Triage & Notifications
@@ -194,5 +195,5 @@ follow its **Write Mode** instructions. The two post-work steps are
 - Operate on any repo not present in `$vault/tasks/` or `$vault/notes/`
 - Execute bulk operations without presenting a summary and receiving explicit user confirmation
 - Write project status documents outside `$vault/projects/`
-- Apply `in-progress` or `review-ready` labels — that is the implementors' job; PM creates the labels, implementors apply them
+- Apply `in-progress`, `local-review`, or `peer-review` labels — that is the implementors' job; PM creates the labels, implementors apply them
 - Use `gh api` to perform operations that are otherwise hard-denied (e.g., do not use `gh api` to merge PRs, push code, or create repositories)

--- a/src/tools/fm/_lib.ts
+++ b/src/tools/fm/_lib.ts
@@ -92,7 +92,8 @@ export const STATUS_ENUMS: Record<string, string[]> = {
   "tasks/": [
     "📋 todo",
     "🔨 in-progress",
-    "🔍 in-review",
+    "🔍 local-review",
+    "📤 peer-review",
     "✅ complete",
     "🚫 closed",
   ],

--- a/src/vault/AGENTS.md
+++ b/src/vault/AGENTS.md
@@ -136,13 +136,14 @@ All status fields use emoji-prefixed values. Plain strings (`todo`, `complete`, 
 
 #### Schemas (Task file class)
 
-| Status           | Meaning                           |
-| ---------------- | --------------------------------- |
-| `📋 todo`        | Planned, not started              |
-| `🔨 in-progress` | Active implementation             |
-| `🔍 in-review`   | Implementation done, under review |
-| `✅ complete`    | Done                              |
-| `🚫 closed`      | Cancelled or superseded           |
+| Status            | Meaning                                   |
+| ----------------- | ----------------------------------------- |
+| `📋 todo`         | Planned, not started                      |
+| `🔨 in-progress`  | Active implementation                     |
+| `🔍 local-review` | Implementation done, awaiting user review |
+| `📤 peer-review`  | PR pushed, awaiting maintainer review     |
+| `✅ complete`     | Done                                      |
+| `🚫 closed`       | Cancelled or superseded                   |
 
 #### Reviews (Task file class)
 

--- a/src/vault/_misc/fileClasses/Task.md
+++ b/src/vault/_misc/fileClasses/Task.md
@@ -18,7 +18,13 @@ savedViews:
         name: status
         direction: asc
         priority: 2
-        customOrder: []
+        customOrder:
+          - 🔨 in-progress
+          - 📋 todo
+          - 🔍 local-review
+          - 📤 peer-review
+          - ✅ complete
+          - 🚫 closed
     filters:
       - id: Task____file
         name: file

--- a/src/vault/_misc/fileClasses/Task.md
+++ b/src/vault/_misc/fileClasses/Task.md
@@ -180,9 +180,10 @@ fields:
       valuesList:
         "0": 📋 todo
         "1": 🔨 in-progress
-        "2": 🔍 in-review
-        "3": ✅ complete
-        "4": 🚫 closed
+        "2": 🔍 local-review
+        "3": 📤 peer-review
+        "4": ✅ complete
+        "5": 🚫 closed
   - name: priority
     type: Select
     id: priority

--- a/src/vault/_misc/templates/schema.md
+++ b/src/vault/_misc/templates/schema.md
@@ -24,15 +24,15 @@ date: YYYY-MM-DD
 
 ### Frontmatter fields
 
-| Field      | Description                                                                      |
-| ---------- | -------------------------------------------------------------------------------- |
-| `repo`     | `<owner>/<repo>` identifier                                                      |
-| `issue`    | GitHub issue link (e.g. `[#1](https://github.com/owner/repo/issues/1)`) or blank |
-| `branch`   | Target branch name                                                               |
-| `status`   | `📋 todo` / `🔨 in-progress` / `🔍 in-review` / `✅ complete` / `🚫 closed`      |
-| `task`     | Task name (kebab-case, matches directory name under `tasks/`)                    |
-| `priority` | `🔥 critical` / `🔴 high` / `🟡 medium` / `🟢 low` / `🟣 non-work`               |
-| `date`     | Creation date (YYYY-MM-DD)                                                       |
+| Field      | Description                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------------- |
+| `repo`     | `<owner>/<repo>` identifier                                                                       |
+| `issue`    | GitHub issue link (e.g. `[#1](https://github.com/owner/repo/issues/1)`) or blank                  |
+| `branch`   | Target branch name                                                                                |
+| `status`   | `📋 todo` / `🔨 in-progress` / `🔍 local-review` / `📤 peer-review` / `✅ complete` / `🚫 closed` |
+| `task`     | Task name (kebab-case, matches directory name under `tasks/`)                                     |
+| `priority` | `🔥 critical` / `🔴 high` / `🟡 medium` / `🟢 low` / `🟣 non-work`                                |
+| `date`     | Creation date (YYYY-MM-DD)                                                                        |
 
 ## Problem
 


### PR DESCRIPTION
## Summary

Fixes #76 — Splits the single `in-review` status into `local-review` and `peer-review` in enums, templates, file class, and agent prompts. Updates default view sort order.

## Commits

```
(no commits ahead of main)
```

## Diff summary

```
(no diff)
```