### PR TITLE
fix: pass SSH_AUTH_SOCK through to sandbox containers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,6 +192,30 @@ at `/root/.config/opencode`, sets up: sandbox-by-default, custom image,
 vault bind-mount (RW), credential passthrough (`GH_TOKEN`, `GIT_CONFIG_COUNT`),
 and resource limits (4 CPU / 8 GB RAM).
 
+### SSH agent in containers
+
+Sandbox containers require access to the host SSH agent for commit signing
+and SSH-based git operations (push, fetch, rebase). The AoE config handles
+this via two mechanisms:
+
+1. **`mount_ssh = true`** — mounts the host SSH agent socket file into the
+   container (handled by AoE).
+2. **`SSH_AUTH_SOCK` passthrough** — the env var is passed from the host so
+   processes inside the container can locate the socket.
+
+Both are configured in the AoE config templates (`src/aoe-config.toml` and
+`src/aoe-profile.toml`).
+
+**Troubleshooting:** If git operations fail with `ssh_askpass: exec(...): No
+such file or directory`, verify:
+
+1. The SSH agent is running on the host: `ssh-add -l` should list at least
+   one key.
+2. `SSH_AUTH_SOCK` is set on the host: `echo $SSH_AUTH_SOCK` should print a
+   socket path.
+3. The socket file exists: `ls -la $SSH_AUTH_SOCK` should show a socket.
+4. Inside the container, `SSH_AUTH_SOCK` is set and the socket is accessible.
+
 ---
 
 ## Conventions

--- a/src/aoe-config.toml
+++ b/src/aoe-config.toml
@@ -17,7 +17,7 @@ default_image = "cubething-occonf-sandbox:latest"
 auto_cleanup = false
 cpu_limit = "4"
 memory_limit = "8g"
-mount_ssh = false
+mount_ssh = true
 
 extra_volumes = [
     "{{AGENT_VAULT}}:/data/vault",

--- a/src/aoe-profile.toml
+++ b/src/aoe-profile.toml
@@ -26,6 +26,9 @@ environment = [
     "GH_TOKEN={{GH_TOKEN}}",
     # NTFY_TOPIC: per-profile ntfy topic from profiles.toml
     "NTFY_TOPIC={{NTFY_TOPIC}}",
+    # SSH_AUTH_SOCK (bare key = passthrough from host): ensures the container
+    # can reach the host SSH agent for commit signing and SSH git operations.
+    "SSH_AUTH_SOCK",
     # SANDBOX_USER/GROUP/UID/GID: Docker user configuration from profiles.toml
     "SANDBOX_USER={{SANDBOX_USER}}",
     "SANDBOX_GROUP={{SANDBOX_GROUP}}",


### PR DESCRIPTION
## Summary

Fixes #70 — Passes the host SSH agent socket into sandbox containers via bind-mount and environment variable, with troubleshooting docs in CONTRIBUTING.md.

## Commits

```
(no commits ahead of main)
```

## Diff summary

```
(no diff)
```