### PR TITLE
feat: add labels and project params to create_issue tool

### DIFF
--- a/src/agents/planner.md
+++ b/src/agents/planner.md
@@ -95,29 +95,30 @@ automatically if the repo uses the bare/worktree layout.
    and be added to the correct project board. Follow this process:
 
    a. Run `vault_cache` to refresh the GitHub metadata cache for the repo's
-      owner. This populates `$AGENT_VAULT/_misc/cache/<owner>.json` with
-      current labels, projects, and milestones.
+   owner. This populates `$AGENT_VAULT/_misc/cache/<owner>.json` with
+   current labels, projects, and milestones.
 
    b. If you already passed `labels` and `project` to `create_issue` in step 6,
-      verify they were applied. If not (or if `create_issue` was called without
-      them), apply them now using `gh issue edit`:
-      ```
-      gh issue edit <number> -R <owner>/<repo> --add-label <label> --add-project <project>
-      ```
+   verify they were applied. If not (or if `create_issue` was called without
+   them), apply them now using `gh issue edit`:
+
+   ```
+   gh issue edit <number> -R <owner>/<repo> --add-label <label> --add-project <project>
+   ```
 
    c. If you are unsure which label(s) or project board to use, you **MUST**
-      ask the user using the `question` tool. Offer the available options
-      discovered from the cache. Do NOT guess or skip.
+   ask the user using the `question` tool. Offer the available options
+   discovered from the cache. Do NOT guess or skip.
 
    d. For labels, select from the repo's available labels. Common mappings:
-      - Bug fix / broken behavior → `bug`
-      - New feature / capability → `enhancement`
-      - Documentation changes → `documentation`
-      - If multiple apply, use multiple labels.
+   - Bug fix / broken behavior → `bug`
+   - New feature / capability → `enhancement`
+   - Documentation changes → `documentation`
+   - If multiple apply, use multiple labels.
 
    e. For project boards, select from the owner's available projects.
-      If the repo or task context makes the correct board obvious, use it.
-      Otherwise, ask the user.
+   If the repo or task context makes the correct board obvious, use it.
+   Otherwise, ask the user.
 
    **Never skip labeling or project assignment.** If the `question` tool is
    unavailable or the user declines to answer, note it in the schema and
@@ -125,23 +126,23 @@ automatically if the repo uses the bare/worktree layout.
 
 > **Important:** If you don't know which labels or project board to use, you
 > MUST ask the user using the `question` tool. Do not guess or skip. Every
-> issue must leave the planner workflow with labels and a project assignment.
-8. **Link** the issue back into the schema header.
-9. **Cross-reference PRs** — if the issue you just created relates to an open
-   PR (e.g., a bug found during CI, a design question from review, a follow-up
-   task), post a comment on the PR. Load the `github` skill and use the
-   `github_comment` tool:
-   ```
-   github_comment({
-     repo: "<owner>/<repo>",
-     number: <pr-number>,
-     body: "Opened #<issue-number> to track <short description>.",
-     agent: "planner",
-     type: "pr"
-   })
-   ```
-   Skip this step if there is no related PR or if the issue is the PR's own
-   tracking issue.
+> issue must leave the planner workflow with labels and a project assignment. 8. **Link** the issue back into the schema header. 9. **Cross-reference PRs** — if the issue you just created relates to an open
+> PR (e.g., a bug found during CI, a design question from review, a follow-up
+> task), post a comment on the PR. Load the `github` skill and use the
+> `github_comment` tool:
+
+```
+github_comment({
+  repo: "<owner>/<repo>",
+  number: <pr-number>,
+  body: "Opened #<issue-number> to track <short description>.",
+  agent: "planner",
+  type: "pr"
+})
+```
+
+Skip this step if there is no related PR or if the issue is the PR's own
+tracking issue.
 
 ## Research
 

--- a/src/agents/planner.md
+++ b/src/agents/planner.md
@@ -77,15 +77,55 @@ automatically if the repo uses the bare/worktree layout.
    Present the schema path and wait for feedback. If the user requests
    changes, iterate on the schema and ask for review again.
 6. **Create** a GitHub issue using the `create_issue` tool. Pass the schema file
-   path and the `repo` from frontmatter:
+   path, the `repo` from frontmatter, and any labels/project determined in
+   the previous step:
    ```
-   create_issue({ schema_file: "$schema_file", repo: "<owner>/<repo>" })
+   create_issue({
+     schema_file: "$schema_file",
+     repo: "<owner>/<repo>",
+     labels: "<comma-separated labels>",
+     project: "<project title>"
+   })
    ```
    The tool reads the file from disk, extracts the H1 as the title, extracts
    the `## Problem` section as a visible summary, and wraps the full content in
    a `<details>` block. You do NOT need to read the schema file into context
    for this step.
-7. **Add** the issue to the project board and set milestone.
+7. **Label and project assignment.** Every issue MUST have at least one label
+   and be added to the correct project board. Follow this process:
+
+   a. Run `vault_cache` to refresh the GitHub metadata cache for the repo's
+      owner. This populates `$AGENT_VAULT/_misc/cache/<owner>.json` with
+      current labels, projects, and milestones.
+
+   b. If you already passed `labels` and `project` to `create_issue` in step 6,
+      verify they were applied. If not (or if `create_issue` was called without
+      them), apply them now using `gh issue edit`:
+      ```
+      gh issue edit <number> -R <owner>/<repo> --add-label <label> --add-project <project>
+      ```
+
+   c. If you are unsure which label(s) or project board to use, you **MUST**
+      ask the user using the `question` tool. Offer the available options
+      discovered from the cache. Do NOT guess or skip.
+
+   d. For labels, select from the repo's available labels. Common mappings:
+      - Bug fix / broken behavior → `bug`
+      - New feature / capability → `enhancement`
+      - Documentation changes → `documentation`
+      - If multiple apply, use multiple labels.
+
+   e. For project boards, select from the owner's available projects.
+      If the repo or task context makes the correct board obvious, use it.
+      Otherwise, ask the user.
+
+   **Never skip labeling or project assignment.** If the `question` tool is
+   unavailable or the user declines to answer, note it in the schema and
+   create a triage entry.
+
+> **Important:** If you don't know which labels or project board to use, you
+> MUST ask the user using the `question` tool. Do not guess or skip. Every
+> issue must leave the planner workflow with labels and a project assignment.
 8. **Link** the issue back into the schema header.
 9. **Cross-reference PRs** — if the issue you just created relates to an open
    PR (e.g., a bug found during CI, a design question from review, a follow-up

--- a/src/tools/create_issue.ts
+++ b/src/tools/create_issue.ts
@@ -9,7 +9,8 @@ export default tool({
     "Create a GitHub issue from a schema Markdown file. " +
     "Extracts the H1 heading as the issue title. The body contains " +
     "the '## Problem' section as a visible summary, plus the full " +
-    "schema in a <details> block. Returns the issue URL.",
+    "schema in a <details> block. Optionally applies labels and " +
+    "adds the issue to a project board. Returns the issue URL.",
   args: {
     schema_file: tool.schema
       .string()
@@ -17,6 +18,20 @@ export default tool({
     repo: tool.schema
       .string()
       .describe("GitHub owner/repo slug (e.g. 'ada-x64/opencode-config')"),
+    labels: tool.schema
+      .string()
+      .optional()
+      .describe(
+        "Comma-separated label names to apply (e.g. 'bug,enhancement'). " +
+          "Each label is passed as a --label flag to gh issue create.",
+      ),
+    project: tool.schema
+      .string()
+      .optional()
+      .describe(
+        "Project board title to add the issue to (e.g. 'wf'). " +
+          "Passed as --project to gh issue create.",
+      ),
   },
   async execute(args) {
     const raw = await readFile(args.schema_file, "utf-8");
@@ -57,13 +72,38 @@ export default tool({
       ? `${problem}\n\n<details>\n<summary>Full schema</summary>\n\n${content}\n\n</details>`
       : `<details>\n<summary>Full schema</summary>\n\n${content}\n\n</details>`;
 
+    // Build dynamic args for gh issue create
+    const ghArgs: string[] = [
+      "issue",
+      "create",
+      "-R",
+      args.repo,
+      "--title",
+      title,
+    ];
+
+    // Add label flags (one --label per label)
+    if (args.labels) {
+      for (const label of args.labels.split(",")) {
+        const trimmed = label.trim();
+        if (trimmed) {
+          ghArgs.push("--label", trimmed);
+        }
+      }
+    }
+
+    // Add project flag
+    if (args.project) {
+      ghArgs.push("--project", args.project);
+    }
+
     // Write to temp file, run gh, then clean up
     const tmpDir = await mkdtemp(join(tmpdir(), "create-issue-"));
     const tmpFile = join(tmpDir, "body.md");
     try {
       await writeFile(tmpFile, body, "utf-8");
-      const result =
-        await Bun.$`gh issue create -R ${args.repo} --title ${title} --body-file ${tmpFile}`.text();
+      ghArgs.push("--body-file", tmpFile);
+      const result = await Bun.$`gh ${ghArgs}`.text();
       return result.trim();
     } finally {
       await rm(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Fixes #67 — Adds `labels` and `project` parameters to the create_issue tool and updates the planner agent prompt with a label/project metadata workflow.

## Commits

```
(no commits ahead of main)
```

## Diff summary

```
(no diff)
```