### PR TITLE
feat: add session_start tool and make start_epoch optional in notify

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,7 +345,7 @@ call tools directly — there are no shell scripts to invoke.
 | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Frontmatter | `fm_read`, `fm_write`                                                                                                                              |
 | Worktree    | `wt_detect`, `wt_owner_repo`, `wt_switch_branch`, `wt_cleanup`                                                                                     |
-| Notify      | `notify_triage`, `notify_start`, `session_notify`                                                                                                                  |
+| Notify      | `notify_triage`, `notify_start`, `session_notify`                                                                                                  |
 | Triage      | `triage_write`                                                                                                                                     |
 | Vault       | `vault_cache`, `vault_edit`, `vault_find`, `vault_gc`, `vault_init`, `vault_lint`, `vault_ls`, `vault_mv`, `vault_read`, `vault_rm`, `vault_write` |
 | GitHub      | `create_issue`, `create_pr`, `github_comment`                                                                                                      |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,8 @@ opencode-config/
 │   │   ├── notify/            #     Notification tools
 │   │   │   ├── _lib.ts        #       Shared notification helpers
 │   │   │   ├── triage.ts      #       notify_triage tool
-│   │   │   └── session.ts     #       session_notify tool
+│   │   │   ├── session.ts     #       session_notify tool
+│   │   │   └── start.ts       #       notify_start tool
 │   │   ├── notify.ts          #     Barrel export for notify/ tools
 │   │   ├── triage/            #     Triage tools
 │   │   │   └── write.ts       #       triage_write tool
@@ -344,7 +345,7 @@ call tools directly — there are no shell scripts to invoke.
 | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Frontmatter | `fm_read`, `fm_write`                                                                                                                              |
 | Worktree    | `wt_detect`, `wt_owner_repo`, `wt_switch_branch`, `wt_cleanup`                                                                                     |
-| Notify      | `notify_triage`, `session_notify`                                                                                                                  |
+| Notify      | `notify_triage`, `notify_start`, `session_notify`                                                                                                                  |
 | Triage      | `triage_write`                                                                                                                                     |
 | Vault       | `vault_cache`, `vault_edit`, `vault_find`, `vault_gc`, `vault_init`, `vault_lint`, `vault_ls`, `vault_mv`, `vault_read`, `vault_rm`, `vault_write` |
 | GitHub      | `create_issue`, `create_pr`, `github_comment`                                                                                                      |

--- a/src/prompts/audit.md
+++ b/src/prompts/audit.md
@@ -99,16 +99,18 @@ Handle directly — without dispatching a subagent — when:
 
 ## Completion Notifications
 
-When handling a direct task (no subagent dispatched), capture the start time:
-
-```bash
-_start=$(date +%s)
-```
-
-When complete, call the `session_notify` tool to conditionally notify:
+When handling a direct task (no subagent dispatched), call `notify_start` at
+the beginning of work:
 
 ```
-session_notify({ start_epoch: "<_start value>", icon: "auditor", task: "<context>", headline: "<headline>" })
+notify_start({})
+```
+
+When complete, call `notify_session` — it reads the stored start time
+automatically:
+
+```
+notify_session({ icon: "auditor", task: "<context>", headline: "<headline>" })
 ```
 
 **Skip this** if a subagent was dispatched — subagents handle their own

--- a/src/prompts/build.md
+++ b/src/prompts/build.md
@@ -242,16 +242,18 @@ gh api repos/<owner>/<repo>/contents/<path> -q .content | base64 -d
 
 ## Completion Notifications
 
-When handling a direct task (no subagent dispatched), capture the start time:
-
-```bash
-_start=$(date +%s)
-```
-
-When complete, call the `session_notify` tool to conditionally notify:
+When handling a direct task (no subagent dispatched), call `notify_start` at
+the beginning of work:
 
 ```
-session_notify({ start_epoch: "<_start value>", icon: "build", task: "<context>", headline: "<headline>" })
+notify_start({})
+```
+
+When complete, call `notify_session` — it reads the stored start time
+automatically:
+
+```
+notify_session({ icon: "build", task: "<context>", headline: "<headline>" })
 ```
 
 **Skip this** if a subagent was dispatched — subagents handle their own

--- a/src/prompts/plan.md
+++ b/src/prompts/plan.md
@@ -146,16 +146,18 @@ Handle directly — without dispatching a subagent — when the user asks you to
 
 ## Completion Notifications
 
-When handling a direct task (no subagent dispatched), capture the start time:
-
-```bash
-_start=$(date +%s)
-```
-
-When complete, call the `session_notify` tool to conditionally notify:
+When handling a direct task (no subagent dispatched), call `notify_start` at
+the beginning of work:
 
 ```
-session_notify({ start_epoch: "<_start value>", icon: "plan", task: "<context>", headline: "<headline>" })
+notify_start({})
+```
+
+When complete, call `notify_session` — it reads the stored start time
+automatically:
+
+```
+notify_session({ icon: "plan", task: "<context>", headline: "<headline>" })
 ```
 
 **Skip this** if a subagent was dispatched — subagents handle their own

--- a/src/tools/notify.ts
+++ b/src/tools/notify.ts
@@ -1,2 +1,3 @@
 export { default as triage } from "./notify/triage";
 export { default as session } from "./notify/session";
+export { default as start } from "./notify/start";

--- a/src/tools/notify/_lib.ts
+++ b/src/tools/notify/_lib.ts
@@ -1,6 +1,18 @@
 import path from "path";
 import fs from "fs/promises";
 
+// Module-level session state
+let _sessionStartEpoch: number | null = null;
+
+export function setSessionStart(epoch?: number): number {
+  _sessionStartEpoch = epoch ?? Math.floor(Date.now() / 1000);
+  return _sessionStartEpoch;
+}
+
+export function getSessionStart(): number | null {
+  return _sessionStartEpoch;
+}
+
 export async function notifyTriage(opts: {
   type: string;
   task: string;

--- a/src/tools/notify/_lib.ts
+++ b/src/tools/notify/_lib.ts
@@ -13,6 +13,11 @@ export function getSessionStart(): number | null {
   return _sessionStartEpoch;
 }
 
+/** @internal — reset state for testing only */
+export function _resetSessionStart(): void {
+  _sessionStartEpoch = null;
+}
+
 export async function notifyTriage(opts: {
   type: string;
   task: string;

--- a/src/tools/notify/session.ts
+++ b/src/tools/notify/session.ts
@@ -1,5 +1,5 @@
 import { tool } from "@opencode-ai/plugin";
-import { notifyTriage } from "./_lib";
+import { getSessionStart, notifyTriage } from "./_lib";
 
 export default tool({
   description:
@@ -11,8 +11,9 @@ export default tool({
   args: {
     start_epoch: tool.schema
       .string()
+      .optional()
       .describe(
-        "Unix epoch (seconds) captured at the start of work via date +%s",
+        "Unix epoch (seconds). If omitted, uses the value from session_start.",
       ),
     icon: tool.schema
       .string()
@@ -29,12 +30,21 @@ export default tool({
       .describe("Notification headline (default: 'Session Task Complete')"),
   },
   async execute(args) {
-    if (!/^\d+$/.test(args.start_epoch)) {
+    let startStr = args.start_epoch;
+    if (!startStr) {
+      const stored = getSessionStart();
+      if (stored === null) {
+        return "No start_epoch provided and session_start was never called";
+      }
+      startStr = stored.toString();
+    }
+
+    if (!/^\d+$/.test(startStr)) {
       return "Invalid start_epoch — must be a Unix timestamp";
     }
 
     const now = Math.floor(Date.now() / 1000);
-    const start = parseInt(args.start_epoch, 10);
+    const start = parseInt(startStr, 10);
     const elapsed = now - start;
 
     if (elapsed <= 180) {

--- a/src/tools/notify/start.ts
+++ b/src/tools/notify/start.ts
@@ -1,0 +1,14 @@
+import { tool } from "@opencode-ai/plugin";
+import { setSessionStart } from "./_lib";
+
+export default tool({
+  description:
+    "Record the session start time. Call this once at the beginning of " +
+    "direct work. The stored timestamp is used automatically by " +
+    "notify_session — no need to pass start_epoch manually.",
+  args: {},
+  async execute() {
+    const epoch = setSessionStart();
+    return `Session start recorded: ${epoch} (${new Date(epoch * 1000).toISOString()})`;
+  },
+});

--- a/tests/tools/session-notify.test.ts
+++ b/tests/tools/session-notify.test.ts
@@ -1,8 +1,16 @@
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, beforeEach } from "bun:test";
 import session_notify from "../../src/tools/notify/session";
+import {
+  setSessionStart,
+  _resetSessionStart,
+} from "../../src/tools/notify/_lib";
 import { execute_tool } from "./_lib";
 
 describe("session_notify", () => {
+  beforeEach(() => {
+    _resetSessionStart();
+  });
+
   it("has the correct description", () => {
     expect(session_notify.description).toContain("3 minutes");
   });
@@ -49,7 +57,7 @@ describe("session_notify", () => {
 
   it("would notify for a start epoch older than 3 minutes", async () => {
     // 4 minutes ago — crosses the 180s threshold.
-    // notify.sh will fail silently in CI (no ntfy configured), but the
+    // notifyTriage will fail silently in CI (no ntfy configured), but the
     // tool should still return the "Notification sent" message.
     const fourMinsAgo = (Math.floor(Date.now() / 1000) - 240).toString();
     const result = await execute_tool(session_notify, {
@@ -60,5 +68,47 @@ describe("session_notify", () => {
     });
     expect(result).toContain("minutes");
     expect(result).not.toContain("below");
+  });
+
+  it("returns error when start_epoch omitted and session_start never called", async () => {
+    const result = await execute_tool(session_notify, {
+      icon: "build",
+    });
+    expect(result).toContain("session_start was never called");
+  });
+
+  it("uses stored epoch when start_epoch omitted after session_start", async () => {
+    // Set a recent start — should be below threshold
+    setSessionStart();
+    const result = await execute_tool(session_notify, {
+      icon: "build",
+    });
+    expect(result).toContain("below");
+    expect(result).toMatch(/\d+s/);
+  });
+
+  it("uses stored epoch for above-threshold notification", async () => {
+    // Set start to 4 minutes ago
+    const fourMinsAgo = Math.floor(Date.now() / 1000) - 240;
+    setSessionStart(fourMinsAgo);
+    const result = await execute_tool(session_notify, {
+      icon: "build",
+      task: "test-owner/test-repo/test-task",
+      headline: "Test Complete",
+    });
+    expect(result).toContain("minutes");
+    expect(result).not.toContain("below");
+  });
+
+  it("explicit start_epoch takes precedence over stored value", async () => {
+    // Store a value from 4 minutes ago (would trigger notification)
+    setSessionStart(Math.floor(Date.now() / 1000) - 240);
+    // But pass a recent explicit epoch (should be below threshold)
+    const now = Math.floor(Date.now() / 1000).toString();
+    const result = await execute_tool(session_notify, {
+      start_epoch: now,
+      icon: "build",
+    });
+    expect(result).toContain("below");
   });
 });

--- a/tests/tools/session-start.test.ts
+++ b/tests/tools/session-start.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "bun:test";
+import session_start from "../../src/tools/notify/start";
+import { execute_tool } from "./_lib";
+
+describe("session_start (notify_start)", () => {
+  it("has the correct description", () => {
+    expect(session_start.description).toContain("session start");
+  });
+
+  it("returns a recorded epoch", async () => {
+    const before = Math.floor(Date.now() / 1000);
+    const result = await execute_tool(session_start, {});
+    const after = Math.floor(Date.now() / 1000);
+
+    expect(result).toContain("Session start recorded");
+    const match = result.match(/recorded: (\d+)/);
+    expect(match).not.toBeNull();
+    const epoch = parseInt(match![1]!, 10);
+    expect(epoch).toBeGreaterThanOrEqual(before);
+    expect(epoch).toBeLessThanOrEqual(after);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #69 — Adds a new `session_start` tool that records the session start timestamp, makes `start_epoch` optional in `notify_session` (auto-reads from session_start), and updates agent prompts.

## Commits

```
(no commits ahead of main)
```

## Diff summary

```
(no diff)
```