### PR TITLE
fix: add syncToRemote helper to reset stale local branches to remote HEAD

### DIFF
--- a/src/tools/wt/switch_branch.ts
+++ b/src/tools/wt/switch_branch.ts
@@ -3,6 +3,34 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import { wtBareRoot, wtDetect } from "./_lib";
 
+/**
+ * If origin/<branch> exists, fetch it and hard-reset the local branch to match.
+ * No-op if the branch has no remote tracking counterpart.
+ */
+async function syncToRemote(wtPath: string, branch: string): Promise<void> {
+  // Fetch the specific branch from origin (no-op if origin doesn't have it)
+  const fetch =
+    await Bun.$`git -C ${wtPath} fetch --no-tags origin ${branch}`.nothrow();
+  if (fetch.exitCode !== 0) return; // No remote tracking — leave as-is
+
+  // Check if origin/<branch> ref exists
+  const refCheck =
+    await Bun.$`git -C ${wtPath} rev-parse --verify origin/${branch}`.nothrow();
+  if (refCheck.exitCode !== 0) return; // No remote ref — leave as-is
+
+  // Compare local HEAD with remote
+  const localSha = (
+    await Bun.$`git -C ${wtPath} rev-parse HEAD`.text()
+  ).trim();
+  const remoteSha = (
+    await Bun.$`git -C ${wtPath} rev-parse origin/${branch}`.text()
+  ).trim();
+
+  if (localSha !== remoteSha) {
+    await Bun.$`git -C ${wtPath} reset --hard origin/${branch}`;
+  }
+}
+
 export default tool({
   description:
     "Switch to a branch in a repo-type-aware way. For bare repos/worktrees, " +
@@ -29,7 +57,10 @@ export default tool({
       const bareRoot = await wtBareRoot(repo_path);
       const newWt = path.join(bareRoot, branch);
 
-      if (existsSync(newWt)) return newWt;
+      if (existsSync(newWt)) {
+        await syncToRemote(newWt, branch);
+        return newWt;
+      }
 
       // Try creating a new branch in the worktree; fall back to an existing branch
       const addNew =
@@ -44,6 +75,7 @@ export default tool({
         }
       }
 
+      await syncToRemote(newWt, branch);
       return newWt;
     }
 
@@ -53,6 +85,7 @@ export default tool({
       if (switchNew.exitCode !== 0) {
         await Bun.$`git -C ${repo_path} switch ${branch}`;
       }
+      await syncToRemote(repo_path, branch);
       return repo_path;
     }
 

--- a/src/tools/wt/switch_branch.ts
+++ b/src/tools/wt/switch_branch.ts
@@ -19,9 +19,7 @@ async function syncToRemote(wtPath: string, branch: string): Promise<void> {
   if (refCheck.exitCode !== 0) return; // No remote ref — leave as-is
 
   // Compare local HEAD with remote
-  const localSha = (
-    await Bun.$`git -C ${wtPath} rev-parse HEAD`.text()
-  ).trim();
+  const localSha = (await Bun.$`git -C ${wtPath} rev-parse HEAD`.text()).trim();
   const remoteSha = (
     await Bun.$`git -C ${wtPath} rev-parse origin/${branch}`.text()
   ).trim();

--- a/tests/tools/worktree.test.ts
+++ b/tests/tools/worktree.test.ts
@@ -81,7 +81,9 @@ beforeAll(async () => {
 
   // Create a stale local branch "remote-test" in the bare repo that's behind
   // (points to the initial commit, not the two extra ones)
-  await Bun.$`git -C ${bareDir}/.bare branch remote-test HEAD`.quiet().nothrow();
+  await Bun.$`git -C ${bareDir}/.bare branch remote-test HEAD`
+    .quiet()
+    .nothrow();
 });
 
 afterAll(async () => {
@@ -235,8 +237,7 @@ describe("wt_switch_branch", () => {
 
     // Should be on the branch, at the same commit as main (since it was
     // branched from main and has no remote)
-    const branch =
-      await Bun.$`git -C ${wtPath} branch --show-current`.text();
+    const branch = await Bun.$`git -C ${wtPath} branch --show-current`.text();
     expect(branch.trim()).toBe("local-only-test");
   });
 });

--- a/tests/tools/worktree.test.ts
+++ b/tests/tools/worktree.test.ts
@@ -59,6 +59,29 @@ beforeAll(async () => {
   // Create the main worktree
   await Bun.$`git -C ${bareDir}/.bare worktree add ${bareDir}/main main`.quiet();
   mainWt = path.join(bareDir, "main");
+
+  // --- Remote-ahead branch setup for sync tests ---
+  // Create a separate upstream bare repo to act as origin
+  const upstream = path.join(tmp, "upstream.git");
+  await Bun.$`git clone --bare ${bareDir}/.bare ${upstream}`.quiet();
+
+  // Add origin remote to our bare repo pointing to the upstream
+  await Bun.$`git -C ${bareDir}/.bare remote add origin ${upstream}`.quiet();
+  await Bun.$`git -C ${bareDir}/.bare fetch origin`.quiet();
+
+  // Clone upstream, create a branch with extra commits, push it back.
+  // This simulates a remote that's ahead of the local branch.
+  const advancer = path.join(tmp, "advancer");
+  await Bun.$`git clone ${upstream} ${advancer}`.quiet();
+  await Bun.$`git -C ${advancer} ${gc} checkout -b remote-test`.quiet();
+  await Bun.$`git -C ${advancer} ${gc} commit --allow-empty -m "remote-ahead-1"`.quiet();
+  await Bun.$`git -C ${advancer} ${gc} commit --allow-empty -m "remote-ahead-2"`.quiet();
+  await Bun.$`git -C ${advancer} push origin remote-test`.quiet();
+  await rm(advancer, { recursive: true, force: true });
+
+  // Create a stale local branch "remote-test" in the bare repo that's behind
+  // (points to the initial commit, not the two extra ones)
+  await Bun.$`git -C ${bareDir}/.bare branch remote-test HEAD`.quiet().nothrow();
 });
 
 afterAll(async () => {
@@ -161,6 +184,61 @@ describe("wt_switch_branch", () => {
       await Bun.$`git -C ${clonePath} branch --show-current`.text();
     expect(branch.trim()).toBe("test-branch");
   });
+
+  it("syncs new worktree to remote tracking branch", async () => {
+    const result = await execute_tool(wt_switch_branch, {
+      repo_path: mainWt,
+      branch: "remote-test",
+    });
+
+    const wtPath = path.join(bareDir, "remote-test");
+    expect(result).toBe(wtPath);
+
+    // Verify the worktree is at the remote HEAD (has "remote-ahead-2" commit)
+    const log = await Bun.$`git -C ${wtPath} log --oneline -1`.text();
+    expect(log).toContain("remote-ahead-2");
+  });
+
+  it("syncs existing worktree to remote when called again", async () => {
+    const wtPath = path.join(bareDir, "remote-test");
+
+    // Reset the worktree back to simulate staleness
+    await Bun.$`git -C ${wtPath} reset --hard HEAD~2`.quiet();
+    const staleSha = (
+      await Bun.$`git -C ${wtPath} rev-parse HEAD`.text()
+    ).trim();
+
+    // Call wt_switch_branch again — should sync to remote
+    const result = await execute_tool(wt_switch_branch, {
+      repo_path: mainWt,
+      branch: "remote-test",
+    });
+    expect(result).toBe(wtPath);
+
+    const freshSha = (
+      await Bun.$`git -C ${wtPath} rev-parse HEAD`.text()
+    ).trim();
+    expect(freshSha).not.toBe(staleSha);
+
+    const log = await Bun.$`git -C ${wtPath} log --oneline -1`.text();
+    expect(log).toContain("remote-ahead-2");
+  });
+
+  it("does not reset a branch with no remote tracking", async () => {
+    const result = await execute_tool(wt_switch_branch, {
+      repo_path: mainWt,
+      branch: "local-only-test",
+    });
+
+    const wtPath = path.join(bareDir, "local-only-test");
+    expect(result).toBe(wtPath);
+
+    // Should be on the branch, at the same commit as main (since it was
+    // branched from main and has no remote)
+    const branch =
+      await Bun.$`git -C ${wtPath} branch --show-current`.text();
+    expect(branch.trim()).toBe("local-only-test");
+  });
 });
 
 describe("wt_cleanup", () => {
@@ -172,6 +250,20 @@ describe("wt_cleanup", () => {
     const result = await execute_tool(wt_cleanup, { worktree_path: wtPath });
     expect(result).toBeTruthy();
     expect(existsSync(wtPath)).toBe(false);
+  });
+
+  it("removes the remote-test worktree", async () => {
+    const wtPath = path.join(bareDir, "remote-test");
+    if (existsSync(wtPath)) {
+      await execute_tool(wt_cleanup, { worktree_path: wtPath });
+    }
+  });
+
+  it("removes the local-only-test worktree", async () => {
+    const wtPath = path.join(bareDir, "local-only-test");
+    if (existsSync(wtPath)) {
+      await execute_tool(wt_cleanup, { worktree_path: wtPath });
+    }
   });
 
   it("is a no-op for non-worktree paths", async () => {


### PR DESCRIPTION
## Summary

Fixes #68 — Adds a `syncToRemote` helper in `wt_switch_branch` that detects when a local branch has diverged from its remote tracking branch and resets it to remote HEAD, preventing stale ref issues in worktree operations.

## Commits

```
(no commits ahead of main)
```

## Diff summary

```
(no diff)
```